### PR TITLE
Support Custom Model Directories

### DIFF
--- a/client/ayon_comfyui/api/launch_logic.py
+++ b/client/ayon_comfyui/api/launch_logic.py
@@ -227,6 +227,24 @@ def _subproc_launch_ComfyUI() -> subprocess.Popen:
 
     yaml += "".join(paths)
 
+    # custom models
+    if profile.extra_model_dirs:
+        models_map: dict[str, list[str]] = {}
+        for model_path in profile.extra_model_dirs:
+            for model_subdir in Path(model_path).iterdir():
+                if not model_subdir.is_dir():
+                    continue
+
+                if model_paths := models_map.get(model_subdir.name):
+                    model_paths.append(model_subdir.as_posix())
+                else:
+                    models_map[model_subdir.name] = [model_subdir.as_posix()]
+
+        for model_type, model_paths in models_map.items():
+            yaml += f"\n    {model_type}: |"
+            for model_path in model_paths:
+                yaml += f"\n{path_indent}{model_path}"
+
     proc = None
     # Generate temporary file,
     # dont delete tempfile otherwise comfy gets confused

--- a/client/ayon_comfyui/parse_settings.py
+++ b/client/ayon_comfyui/parse_settings.py
@@ -162,6 +162,13 @@ class ComfyLocalSettings:
             )
 
         @property
+        def extra_model_dirs(self) -> list[str]:
+            """Return paths to extra models."""
+            return self._get_launch_profile_setting_path(
+                "extra_custom_model_dirs"
+            )
+
+        @property
         def launch_args(self) -> list[str]:
             """Return launch arguments for profile.
 

--- a/server/local_settings.py
+++ b/server/local_settings.py
@@ -32,6 +32,21 @@ class ComfyLocalProfile(BaseSettingsModel):
         title="Custom node directories MacOsx",
         description="Add MacOsx directories that ComfyUI may search through.",
     )
+    extra_custom_model_dirs_win: list[str] = SettingsField(
+        default_factory=list,
+        title="Custom model directories windows",
+        description="Add windows directories that ComfyUI may search through.",
+    )
+    extra_custom_model_dirs_lin: list[str] = SettingsField(
+        default_factory=list,
+        title="Custom model directories linux",
+        description="Add linux directories that ComfyUI may search through.",
+    )
+    extra_custom_model_dirs_osx: list[str] = SettingsField(
+        default_factory=list,
+        title="Custom model directories MacOsx",
+        description="Add MacOsx directories that ComfyUI may search through.",
+    )
 
     comfy_is_windows_portable: bool = SettingsField(
         default=True,


### PR DESCRIPTION
adds support for custom model directories through local launch profile
- requires addon reupload to server due to settings changes

example settings screenshot
<img width="1128" height="723" alt="image" src="https://github.com/user-attachments/assets/224c79c4-f14e-4954-abef-1210231fe994" />


example output of yaml config
```
ayon_config:
    base_path: "C:/Users/tweak/dev/vfx/clones/ComfyUI"
    custom_nodes: |
        C:/Users/tweak/Downloads/comfy/custom_nodes
        C:/Users/tweak/dev/vfx/ayon/ayon-comfyui-sasbom/client/ayon_comfyui/_comfyui_plugin
    audio_encoders: |
        C:/Users/tweak/Downloads/comfy/models/audio_encoders
        C:/Users/tweak/Downloads/comfy/models_new/audio_encoders
    checkpoints: |
        C:/Users/tweak/Downloads/comfy/models/checkpoints
        C:/Users/tweak/Downloads/comfy/models_new/checkpoints
    clip: |
        C:/Users/tweak/Downloads/comfy/models/clip
        C:/Users/tweak/Downloads/comfy/models_new/clip
    [...]
```