### PR TITLE
Feature: Expand profile configurability with options for generated yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # ComfyUI addon
 ComfyUI integration for AYON.
 
-#### A note on bridging ComfyUI workflows / Workfiles
+#### Migrating settings to ayon_comfyui 0.19 from earlier.
+Tooling is included in `additional_tooling/migrate_json.py`<br>
+Save your data from AYON with the low level settings editor, e.g. <br>
+in Studio Settings / Project settings -> Addons -> ComfyUI (right click) -> `Low-level editor` -> Copy
 
-As of now, tested with ComfyUI 0.18.4.
-Pre 0.17.2, the interface used to be much simpler.<br>
-We account for that in the JS side of the ComfyUI plugin,
-so that a larger number of versions are still usable.
+Then save the contents to a json file.
+
+Then run `python additional_tooling/migration_json.py "path/to/json/ayon_comfyui_settings.json"`<br>
+The console will then fix it for you, and display: `Migrated settings here: path/to/json/ayon_comfyui_settings_migrated.json`,<br>
+which you can then copy into the low level editor once more.
 
 #### A note on https:
 The planned control flow is as follows:

--- a/additional_tooling/migrate_json.py
+++ b/additional_tooling/migrate_json.py
@@ -1,0 +1,19 @@
+"""Small utility for rewriting a json settings file to no longer have
+
+'comfy_setting_name' but plain 'name' keys instead.
+Otherwise, migrating settings can cause crashes.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+RGX_NAME = re.compile(r"\w+_name")
+
+if __name__ == "__main__":
+    cleanup_json = Path(sys.argv[1])
+    text = cleanup_json.read_text("utf-8")
+    cleanup = re.sub(RGX_NAME, "name", text)
+    new_stem = cleanup_json.stem + "_migrated"
+    (cleaned_json := cleanup_json.with_stem(new_stem)).write_text(cleanup)
+    print("Migrated settings here:", str(cleaned_json))

--- a/client/ayon_comfyui/api/launch_logic.py
+++ b/client/ayon_comfyui/api/launch_logic.py
@@ -51,45 +51,26 @@ def safe_excepthook(*args):  # noqa: ANN201, ANN002, D103
 def adjust_consts_comfyui_plugin(plugin_path: Path) -> None:
     """Adjust settings for comfyui plugin."""
     settings, _ = ComfyLocalSettings.pull_committed_settings()
-
-    # javascript = f'export const AYON_WEBUI_PORT = "{settings.port_webui}";'
     python = f"AYON_BACKEND_PORT = {settings.port_backend}"
-
     py_file = plugin_path / "ayon_menu" / "consts.py"
-    # js_file = plugin_path / "ayon_menu" / "js" / "lib" / "consts.js"
 
-    # TODO: We really shouldn't be updating files inside the packaged plugin,
-    #  but for now this is the easiest way to get the settings in there
-    #  without having to do some sort of IPC or environment variable passing
-    #  to comfyUI, which would be more robust but also more work to implement.
-    #
-    #  DONE: inject info about ports through live HTML templating instead
-    #        of JS files.
-    #
-    # COMMENT FROM(@sas): The design philosophy of ComfyUI is very much against
-    #  using environment variables. An important thing to note too, is that
-    #  while an environment variable is easily gotten in python, it's harder to
-    #  do for JS. We also cannot make an environment variable easily accessible
-    #  to JS through python.
-    #  Writing out a file is a valid form of IPC.
-    #  If we still wish to stray
+    # update python consts plugin with port to use.
+    # IPC using the proc Popen is not very wise,
+    # since we can't reliably get a hold of the entire process tree
+    # We communicate with the JS side by templating HTML,
 
     Path(py_file).write_text(python, encoding="utf-8")
 
-    # Path(js_file).write_text(javascript, encoding="utf-8")
-
 
 def _subproc_launch_ComfyUI() -> subprocess.Popen:
-    """Launch local profile."""
+    """Launch local profile.
+
+    Returns:
+        Popen ComfyUI subprocess.
+    """
     settings, profile = ComfyLocalSettings.pull_committed_settings()
 
     # CHECK IF WINDOWS PORTABLE TO TARGET THE RIGHT PYTHON PATH
-    # TODO(@sas): maybe allow for launch using ayon_console.
-    # This would suck, though.
-    # The better solution would be to understand which python is present
-    # by subprocessing launching "python" / "python3" and then doing
-    # sys.executable() to get the path
-    # if nothing works, quit while we are ahead
 
     pythonpath = deduce_default_python_executable()
 
@@ -103,9 +84,8 @@ def _subproc_launch_ComfyUI() -> subprocess.Popen:
             Path(profile.base_folder).parent / "python_embeded" / "python.exe"
         )
 
-    # TEST IMPLEMENTATION OF:
-    # TODO(@sas): add an option for
-    # letting the user manage a python environment themselves
+    # let the user manage a python environment themselves
+    # TODO(@sas): Look into astral uv as an alternative.
 
     if profile.using_managed_venv and not (
         profile.is_windows_portable and profile.current_os == "Windows"
@@ -194,19 +174,7 @@ def _subproc_launch_ComfyUI() -> subprocess.Popen:
         *profile.launch_args,
     ]
 
-    # 8 space | 2 tabs indent to sit below custom nodes
-    path_indent = " " * 8
-
-    # simulate paths comin in from settings
-    # paths = [R"C:\Users\sas.vangulik\Documents\comfy_nodes_ayon"]
-    paths = profile.extra_node_dirs or []
-
-    # TODO(@Sas): Adress following
-    # There needs to be a setting for this so we can point to
-    # a development folder
-    include_content = not profile.omit_packaged_plugin
-
-    if include_content:
+    if not profile.omit_packaged_plugin:
         import ayon_comfyui as comfy_plugin
 
         comfy_plugin_path = (
@@ -215,17 +183,14 @@ def _subproc_launch_ComfyUI() -> subprocess.Popen:
         # inject settings
         adjust_consts_comfyui_plugin(comfy_plugin_path)
 
-        paths.append(str(comfy_plugin_path))
-
-    paths = ["\n" + path_indent + p.replace("\\", "/") for p in paths]
-
-    yaml_folder = profile.base_folder.replace("\\", "/")
+    yaml_folder = Path(profile.base_folder).as_posix()
     yaml = dedent(f"""
             ayon_config:
                 base_path: "{yaml_folder}"
-                custom_nodes: |""")
+            """)
 
-    yaml += "".join(paths)
+    # Construct yaml within profile.
+    yaml += profile.get_customfolders_yaml
 
     proc = None
     # Generate temporary file,
@@ -264,7 +229,7 @@ def _subproc_launch_ComfyUI() -> subprocess.Popen:
     )
 
     # time buffer closing of tempfile, allowing it to be read by comfyUI
-    buffer_time = 20
+    buffer_time = 20.0
 
     def _defer_delete_tmp(*, path: str = "", hold_time: float = 10.0) -> None:
         time.sleep(hold_time)

--- a/client/ayon_comfyui/parse_settings.py
+++ b/client/ayon_comfyui/parse_settings.py
@@ -12,6 +12,7 @@ from ayon_comfyui.api.connection_util import (
     poll_site_availability_timeout,
     poll_site_headers,
 )
+from ayon_comfyui.settings_directory import ComfyUICustomDirectories
 
 DEFAULT_T = TypeVar("DEFAULT_T")
 
@@ -27,11 +28,25 @@ class ComfyLocalSettings:
 
         def __init__(self, profile_dict: dict[str, str]) -> None:
             """Initialize config helper class."""
-            self._name = profile_dict.get("comfy_setting_name")
+            self._name = profile_dict.get("name")
             os_map = {"win32": "win", "linux": "lin", "darwin": "osx"}
             self._os = os_map.get(sys.platform, "lin")
 
             self._profile_dict: dict[str, str] = profile_dict
+
+            custom_dir_list: list[dict] = (
+                self._get_launch_profile_bare_setting("extra_dirs")
+            )
+
+            self._custom_directories = [
+                ComfyUICustomDirectories(dir_dict, self._os)
+                for dir_dict in custom_dir_list
+            ]
+
+            if not self.omit_packaged_plugin:
+                self._custom_directories.append(
+                    ComfyUICustomDirectories.create_default_customnodes_profile()
+                )
 
         def _get_platform_profile_setting(
             self, base_key: str
@@ -70,6 +85,19 @@ class ComfyLocalSettings:
                 "launch_profile"
             )
             return launch_profile.get(f"{base_key}_{self._os}")
+
+        def _get_launch_profile_bare_setting(
+            self, base_key: str
+        ) -> str | dict | list | None:
+            """Used in properties to fetch the right value.
+
+            Returns:
+            Value expected from key
+            """
+            launch_profile: dict[str, str] = self._profile_dict.get(
+                "launch_profile"
+            )
+            return launch_profile.get(base_key)
 
         def _get_launch_profile_setting_path(
             self, base_key: str
@@ -155,10 +183,10 @@ class ComfyLocalSettings:
             return None
 
         @property
-        def extra_node_dirs(self) -> list[str]:
-            """Return paths to extra nodes."""
-            return self._get_launch_profile_setting_path(
-                "extra_custom_node_dirs"
+        def get_customfolders_yaml(self) -> str:
+            """Return indented YAML component of custom folders."""
+            return ComfyUICustomDirectories.generate_yaml(
+                self._custom_directories
             )
 
         @property
@@ -214,6 +242,17 @@ class ComfyLocalSettings:
             old_os = self._os
             self._os = os_name
 
+            profiles_os = [
+                ComfyUICustomDirectories(
+                    custom_dir._directory_settings,  # noqa : SLF001
+                    os_name,
+                )
+                for custom_dir in self._custom_directories
+            ]
+            profiles_dict = ComfyUICustomDirectories.collect_as_dict(
+                profiles_os
+            )
+
             # Run tests
             errors = []
             logs = []
@@ -231,7 +270,10 @@ class ComfyLocalSettings:
                     f"{self.name} | {os_name}: is missing custom "
                     "python path with 'use custom python' specified"
                 )
-            if not self.extra_node_dirs and self.omit_packaged_plugin:
+            if (
+                profiles_dict.get("custom_nodes") is None
+                and self.omit_packaged_plugin
+            ):
                 logs.append(
                     f"{self.name} | {os_name}: is missing extra node"
                     " directory in dev mode. Ayon plugin may be missing."
@@ -381,7 +423,7 @@ class ComfyRemoteSettings:
 
         def __init__(self, profile_dict: dict[str, str]) -> None:
             """Initialize config helper class."""
-            self._name = profile_dict.get("comfy_setting_name")
+            self._name = profile_dict.get("name")
             self._profile_dict: dict[str, str] = profile_dict
 
             self._is_valid = None
@@ -529,11 +571,9 @@ class ComfyRemoteSettings:
         def netloc_backend(self) -> str:
             """Return netloc of webui."""
             url_comfy = urlparse(self.comfy_url)
-            print(url_comfy, self.port_backend)
             url = ComfyRemoteSettings.url_specify_port(
                 url_comfy, self.port_backend
             )
-            print(url)
             return urlparse(url).netloc
 
         @property

--- a/client/ayon_comfyui/settings_directory.py
+++ b/client/ayon_comfyui/settings_directory.py
@@ -1,0 +1,250 @@
+"""Directory processing utilities."""
+
+from __future__ import annotations
+
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+VALID_DIRS = {
+    "custom_nodes",
+    "checkpoints",
+    "diffusion_models",
+    "diffusers",
+    "classifiers",
+    "loras",
+    "style_models",
+    "gligen",
+    "controlnet",
+    "configs",
+    "vae_approx",
+    "vae",
+    "text_encoders",
+    "clip_vision",
+    "upscale_models",
+    "latent_upscale_models",
+    "hypernetworks",
+    "photomaker",
+    "model_patches",
+    "audio_encoders",
+    "unet",  # legacy for diffusion_models
+    "clip",  # legacy for text_encoders
+}
+
+
+class ComfyUICustomDirectories:
+    """Stores custom directories of a given type per OS."""
+
+    def __init__(
+        self,
+        directory_settings: dict[str, Any],
+        os_profile_key: str | None = None,
+    ):
+        """Initialize custom directories for generating config."""
+        self._directory_settings = directory_settings
+        self._os = os_profile_key
+        if os_profile_key is None or os_profile_key not in {
+            "win",
+            "lin",
+            "osx",
+        }:
+            os_map = {"win32": "win", "linux": "lin", "darwin": "osx"}
+            self._os = os_map.get(sys.platform)
+
+        self._dir_profile_name: str = directory_settings["name"]
+        self._dir_type: str = directory_settings["dir_type"]
+        self._is_auto: bool = self._dir_type == "auto"
+
+    @property
+    def dir_profile_name(self) -> str:
+        """Return name of this folder profile subsection."""
+        return self._dir_profile_name
+
+    @property
+    def dir_type(self) -> str:
+        """Return type of this folder profile subsection."""
+        return self._dir_type
+
+    @property
+    def is_auto(self) -> bool:
+        """Return whether profile is auto."""
+        return self._is_auto
+
+    @property
+    def auto_dirs(self) -> list[str]:
+        """Return top level auto search dirs."""
+        if not self._is_auto:
+            return []
+        return self._os_specific_directories
+
+    @property
+    def _os_specific_directories(self) -> list[str]:
+        """Return directory list for current held OS state."""
+        return [
+            Path(directory).as_posix()
+            for directory in self._directory_settings[f"dirs_{self._os}"]
+        ]
+
+    def _traverse_auto(self) -> dict[str, str]:
+        """Returns a dictionary with valid subdirectories."""
+        collect_dict = defaultdict(list)
+        valid_dirs = [
+            dir_
+            for dir_ in self._os_specific_directories
+            if Path(dir_).exists() and Path(dir_).is_dir()
+        ]
+
+        for directory in valid_dirs:
+            valid_subdirs = {
+                subdir.name: subdir.as_posix()
+                for subdir in Path(directory).iterdir()
+                if subdir.is_dir() and subdir.name in VALID_DIRS
+            }
+            [
+                collect_dict[key].append(value)
+                for key, value in valid_subdirs.items()
+            ]
+        return collect_dict
+
+    @property
+    def as_dict(self) -> dict[str, list[str]]:
+        """Returns contents as dictionary."""
+        if self._is_auto:
+            return self._traverse_auto()
+        return {self._dir_type: self._os_specific_directories}
+
+    @property
+    def is_valid(self) -> bool:
+        """Return true if all directories exist."""
+        dirlist = []
+        [dirlist.extend(dirs) for dirs in self.as_dict.values()]
+        if not dirlist:
+            return False
+        return not any(
+            not Path(dir_).exists() or not Path(dir_).is_dir()
+            for dir_ in dirlist
+        )
+
+    @staticmethod
+    def collect_as_dict(custom_dirs: list[ComfyUICustomDirectories]) -> dict:
+        """Return dict with valid keys and paths gathered."""
+        collect_dict = defaultdict(list)
+        # Gather all
+        for custom_dir in custom_dirs:
+            [
+                collect_dict[key].extend(value)
+                for key, value in custom_dir.as_dict.items()
+            ]
+        return collect_dict
+
+    @staticmethod
+    def generate_yaml(custom_dirs: list[ComfyUICustomDirectories]) -> str:
+        """Return indented yaml component for custom directory lists."""
+        tab = " " * 4
+        yaml: str = ""
+        collect_dict = ComfyUICustomDirectories.collect_as_dict(
+            custom_dirs=custom_dirs
+        )
+
+        # Construct yaml
+        for key in collect_dict:
+            entry = f"{tab}{key}: |\n"
+            entry += (
+                "\n".join(f"{tab * 2}{value}" for value in collect_dict[key])
+                + "\n"
+            )
+            yaml += entry
+        return yaml
+
+    @staticmethod
+    def diagnose_missing_dirs(
+        custom_dirs: list[ComfyUICustomDirectories],
+    ) -> list[str]:
+        r"""Return list of directories that do not exist.
+
+        Also reports if list is not 'valid', e.g. is file (extensionless)
+
+        Formatted as:
+
+        [dir profile name] | [folder type] :
+        - [folder 1] does not exist / valid
+        - [folder 2] does not exist / valid
+
+        """
+        diagnostics = []
+        for custom_dir in custom_dirs:
+            if not custom_dir.is_valid:
+                if not custom_dir.is_auto:
+                    diagnostics.append(
+                        f"{custom_dir.dir_profile_name} |"
+                        f" {custom_dir.dir_type} :"
+                    )
+                    non_valid = [
+                        dir_
+                        for dir_ in custom_dir.as_dict[custom_dir.dir_type]
+                        if not Path(dir_).exists() or not Path(dir_).is_dir()
+                    ]
+                    diagnostics.extend(
+                        [
+                            f"- {dir_} does not exist / isn't valid."
+                            for dir_ in non_valid
+                        ]
+                    )
+                else:
+                    diagnostics.append(
+                        f"{custom_dir.dir_profile_name} |"
+                        f" {custom_dir.dir_type} :"
+                    )
+                    auto_dirs = custom_dir.auto_dirs
+                    non_valid_auto = [
+                        dir_
+                        for dir_ in auto_dirs
+                        if not Path(dir_).exists() or not Path(dir_).is_dir()
+                    ]
+                    diagnostics.extend(
+                        [
+                            f"{custom_dir.dir_profile_name} | "
+                            f"{non_valid} does not exist / isn't valid."
+                            for non_valid in non_valid_auto
+                        ]
+                    )
+
+                    for key, dirs in custom_dir.as_dict.items():
+                        non_valid = [
+                            dir_
+                            for dir_ in dirs
+                            if not Path(dir_).exists()
+                            or not Path(dir_).is_dir()
+                        ]
+                        diagnostics.extend(
+                            [
+                                f"- {key} | {dir_} does not exist / "
+                                "isn't valid."
+                                for dir_ in non_valid
+                            ]
+                        )
+        return diagnostics
+
+    @staticmethod
+    def create_default_customnodes_profile() -> ComfyUICustomDirectories:
+        """Return Custom Directory entry with AYON comfyui plugin."""
+        import ayon_comfyui as comfy_plugin
+
+        comfy_plugin_path = (
+            Path(comfy_plugin.__file__).parent / "_comfyui_plugin"
+        )
+        os_map = {"win32": "win", "linux": "lin", "darwin": "osx"}
+        os_key = os_map.get(sys.platform)
+
+        data = {
+            "name": "AYON ComfyUI Default Plugin",
+            "dir_type": "custom_nodes",
+            "dirs_win": [],
+            "dirs_lin": [],
+            "dirs_osx": [],
+        }
+
+        data[f"dirs_{os_key}"] = [comfy_plugin_path]
+
+        return ComfyUICustomDirectories(directory_settings=data)

--- a/client/ayon_comfyui/version.py
+++ b/client/ayon_comfyui/version.py
@@ -1,2 +1,2 @@
 """Package declaring AYON addon 'comfyui' version."""
-__version__ = "0.0.18"
+__version__ = "0.0.19"

--- a/package.py
+++ b/package.py
@@ -8,7 +8,7 @@ title = "ComfyUI"
 app_host_name = "comfyui"
 
 # Required: Valid semantic version (https://semver.org/)
-version = "0.0.18"
+version = "0.0.19"
 
 # Name of client code directory imported in AYON launcher
 # - do not specify if there is no client code

--- a/server/local_settings.py
+++ b/server/local_settings.py
@@ -3,6 +3,93 @@
 from __future__ import annotations
 
 from ayon_server.settings import BaseSettingsModel, SettingsField
+from ayon_server.settings.validators import ensure_unique_names
+from pydantic import validator
+
+# comfyui:
+#      base_path: path/to/comfyui/
+#      # You can use is_default to mark that these folders should be listed
+#      # first, and used as the default dirs for eg downloads
+#      #is_default: true
+#      checkpoints: models/checkpoints/
+#      text_encoders: |
+#           models/text_encoders/
+#           models/clip/  # legacy location still supported
+#      clip_vision: models/clip_vision/
+#      configs: models/configs/
+#      controlnet: models/controlnet/
+#      diffusion_models: |
+#                   models/diffusion_models
+#                   models/unet
+#      embeddings: models/embeddings/
+#      loras: models/loras/
+#      upscale_models: models/upscale_models/
+#      vae: models/vae/
+#      audio_encoders: models/audio_encoders/
+#      model_patches: models/model_patches/
+
+DIR_TYPES_ENUM = [
+    {"label": "Automatic (Based on subdirectory name)", "value": "auto"},
+    {"label": "Custom Nodes", "value": "custom_nodes"},
+    {"label": "Checkpoints", "value": "checkpoints"},
+    {"label": "Diffusion Models", "value": "diffusion_models"},
+    {"label": "Diffusers", "value": "diffusers"},
+    {"label": "Classifiers", "value": "classifiers"},
+    {"label": "LoRAs", "value": "loras"},
+    {"label": "Style Models", "value": "style_models"},
+    {"label": "GLIGEN", "value": "gligen"},
+    {"label": "ControlNet", "value": "controlnet"},
+    {"label": "Configs", "value": "configs"},
+    {"label": "Approximate VAEs", "value": "vae_approx"},
+    {"label": "VAEs", "value": "vae"},
+    {"label": "Text Encoders", "value": "text_encoders"},
+    {"label": "CLIP Vision", "value": "clip_vision"},
+    {"label": "Upscale Models", "value": "upscale_models"},
+    {"label": "Latent Upscale Models", "value": "latent_upscale_models"},
+    {"label": "Hyper Network", "value": "hypernetworks"},
+    {"label": "Photo Maker", "value": "photomaker"},
+    {"label": "Model Patches", "value": "model_patches"},
+    {"label": "Audio Encoders", "value": "audio_encoders"},
+]
+
+
+class LocalProfileDirMapping(BaseSettingsModel):
+    """Stores directories for extra config generation."""
+
+    name: str = SettingsField(
+        "",
+        title="Name",
+        description=("Name used for alias during diagnostics."),
+    )
+
+    dir_type: str = SettingsField(
+        default="auto",
+        title="Folder type",
+        enum_resolver=lambda: DIR_TYPES_ENUM,
+        description=(
+            "Specify what kind of directory is added. "
+            "The directory type specifies what type of files ComfyUI "
+            "expects to be present there. 'Automatic' looks in the "
+            "subdirectory for valid ComfyUI directories using the expected "
+            "names that ComfyUI/folderpaths.py can expect."
+        ),
+    )
+
+    dirs_win: list[str] = SettingsField(
+        default_factory=list,
+        title="Custom directories windows",
+        description="Add windows directories that ComfyUI may search through.",
+    )
+    dirs_lin: list[str] = SettingsField(
+        default_factory=list,
+        title="Custom directories linux",
+        description="Add linux directories that ComfyUI may search through.",
+    )
+    dirs_osx: list[str] = SettingsField(
+        default_factory=list,
+        title="Custom directories MacOsx",
+        description="Add MacOsx directories that ComfyUI may search through.",
+    )
 
 
 class LaunchArgsMappingModel(BaseSettingsModel):
@@ -15,30 +102,14 @@ class LaunchArgsMappingModel(BaseSettingsModel):
 
 
 class ComfyLocalProfile(BaseSettingsModel):
-    """Specifies launch arguments / extra node dirs."""
-
-    extra_custom_node_dirs_win: list[str] = SettingsField(
-        default_factory=list,
-        title="Custom node directories windows",
-        description="Add windows directories that ComfyUI may search through.",
-    )
-    extra_custom_node_dirs_lin: list[str] = SettingsField(
-        default_factory=list,
-        title="Custom node directories linux",
-        description="Add linux directories that ComfyUI may search through.",
-    )
-    extra_custom_node_dirs_osx: list[str] = SettingsField(
-        default_factory=list,
-        title="Custom node directories MacOsx",
-        description="Add MacOsx directories that ComfyUI may search through.",
-    )
+    """Specifies launch arguments / extra dirs."""
 
     comfy_is_windows_portable: bool = SettingsField(
         default=True,
         title="Is windows path a 'portable windows' build?",
         description=(
             "On windows, if the designated folder is a windows portable build "
-            "the plugin will look for python in python_embedded and add the "
+            "the plugin will look for python in python_embeded and add the "
             "--windows-portable flag to launch arguments.",
         ),
     )
@@ -65,11 +136,25 @@ class ComfyLocalProfile(BaseSettingsModel):
         description="Extra launch arguments for MacOsx",
     )
 
+    extra_dirs: list[LocalProfileDirMapping] = SettingsField(
+        default_factory=list,
+        title="Extra directories",
+        description=(
+            "Extra directories for ComfyUI to search through. "
+            "These get added to the generated configuration YAML at start."
+        ),
+    )
+
+    @validator("extra_dirs")
+    def validate_unique_names_dirs(cls, value):
+        ensure_unique_names(value)
+        return value
+
 
 class ComfyLocalSetting(BaseSettingsModel):
     """Comfy Local Executable & Launch profiles settings."""
 
-    comfy_setting_name: str = SettingsField(default="")
+    name: str = SettingsField("", title="Setting name")
 
     comfy_launch_port: int = SettingsField(
         default=8188,
@@ -155,3 +240,8 @@ class ComfyLocalSettings(BaseSettingsModel):
     local_setting_list: list[ComfyLocalSetting] = SettingsField(
         default_factory=list, title="Local configuration entry"
     )
+
+    @validator("local_setting_list")
+    def validate_unique_names_localsettings(cls, value):
+        ensure_unique_names(value)
+        return value

--- a/server/remote_settings.py
+++ b/server/remote_settings.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from ayon_server.settings import BaseSettingsModel, SettingsField
+from ayon_server.settings.validators import ensure_unique_names
+from pydantic import validator
 
 
 class ComfyRemoteSetting(BaseSettingsModel):
     """Comfy Remote Executable & Launch profiles settings."""
 
-    comfy_setting_name: str = SettingsField(default="", title="Entry Name")
+    name: str = SettingsField(default="", title="Entry Name")
 
     server_pulse_port: int = SettingsField(
         55055,
@@ -60,3 +62,8 @@ class ComfyRemoteSettings(BaseSettingsModel):
     remote_setting_list: list[ComfyRemoteSetting] = SettingsField(
         default_factory=list, title="Remote configuration entry"
     )
+
+    @validator("remote_setting_list")
+    def validate_unique_names_remotesettings(cls, value):
+        ensure_unique_names(value)
+        return value


### PR DESCRIPTION
Closes #4 

Allow the launching procedure to do a lot more heavy lifting by leveraging the passing in of extra folders through YAML.

Also includes an automatic mode to pass in an entire folders worth of content, provided the folders match the names mentioned in ComfyUI's folder_paths.py

Here's a set describing all valid folder names:

```py
VALID_DIRS = {
    "custom_nodes",
    "checkpoints",
    "diffusion_models",
    "diffusers",
    "classifiers",
    "loras",
    "style_models",
    "gligen",
    "controlnet",
    "configs",
    "vae_approx",
    "vae",
    "text_encoders",
    "clip_vision",
    "upscale_models",
    "latent_upscale_models",
    "hypernetworks",
    "photomaker",
    "model_patches",
    "audio_encoders",
    "unet",  # legacy for diffusion_models
    "clip",  # legacy for text_encoders
}
```

Also, the name of a setting will now be reflected in the label thanks to a tip by @tweak-wtf