### PR TITLE
Allow for roots[root_key] use

### DIFF
--- a/client/ayon_comfyui/settings_util/template_helper.py
+++ b/client/ayon_comfyui/settings_util/template_helper.py
@@ -39,6 +39,8 @@ def construct_template_data() -> dict[str, Any]:
         project_name=project_name, project_entity=project_entity
     ).roots
 
+    top_roots_dict = {"roots": roots}
+
     return (
         get_template_data(
             project_entity=project_entity,
@@ -49,6 +51,7 @@ def construct_template_data() -> dict[str, Any]:
             username=username,
         )
         | roots
+        | top_roots_dict
     )
 
 

--- a/documentation/setup_guide.md
+++ b/documentation/setup_guide.md
@@ -33,6 +33,9 @@ Note that all string entries in the menu that pertain to paths, can recieve **te
 
 (change root name to preferred root as set up in studio anatomy settings.)
 
+As of 0.0.26, you can also use `{roots[root_name]}` if you so desire.<br>
+This mimicks the way roots work in `applications`.
+
 <details>
 <summary>Setting up a basic local launch profile:</summary>
 


### PR DESCRIPTION
Closes #10 

Why not both?
Allow for both `{root}` and `{roots[root]}` templates.