### PR TITLE
resolves templates for extra launch flags

### DIFF
--- a/client/ayon_comfyui/settings_util/parse_settings.py
+++ b/client/ayon_comfyui/settings_util/parse_settings.py
@@ -199,6 +199,7 @@ class ComfyLocalSettings:
             )
 
         @property
+        @template_wrap
         def launch_args(self) -> list[str]:
             """Return launch arguments for profile.
 


### PR DESCRIPTION
Noticed that Launch Arguments do not resolve templates.
This PR simply wraps `launch_args()` with `template_wrap` decorator.

an example usecase for resolving templates in launch flags is being able to define project-specific user_dirs