### PR TITLE
Use `review` product type for video generations

### DIFF
--- a/client/ayon_comfyui/plugins/create/create_image.py
+++ b/client/ayon_comfyui/plugins/create/create_image.py
@@ -21,7 +21,7 @@ class ImageCreator(Creator):
     this publish.
     """
 
-    identifier = "image"
+    identifier = "io.ayon.creators.comfyui.image"
     label = "AI Image"
     product_type = "image"
     product_base_type = "image"

--- a/client/ayon_comfyui/plugins/create/create_model.py
+++ b/client/ayon_comfyui/plugins/create/create_model.py
@@ -22,7 +22,7 @@ class ModelCreator(Creator):
     this publish.
     """
 
-    identifier = "model"
+    identifier = "io.ayon.creators.comfyui.model"
     label = "AI 3D Model"
     product_type = "model"
     product_base_type = "model"

--- a/client/ayon_comfyui/plugins/create/create_video.py
+++ b/client/ayon_comfyui/plugins/create/create_video.py
@@ -22,7 +22,7 @@ class VideoCreator(Creator):
     this publish.
     """
 
-    identifier = "render"
+    identifier = "io.ayon.creators.comfyui.render"
     label = "AI Video"
     product_base_type = "render"
     product_type = product_base_type

--- a/client/ayon_comfyui/plugins/create/create_video.py
+++ b/client/ayon_comfyui/plugins/create/create_video.py
@@ -22,10 +22,10 @@ class VideoCreator(Creator):
     this publish.
     """
 
-    identifier = "video"
+    identifier = "review"
     label = "AI Video"
-    product_type = "video"
-    product_base_type = "video"
+    product_base_type = "review"
+    product_type = product_base_type
     description = "Video generated using ComfyUI"
 
     default_variant = "Main"

--- a/client/ayon_comfyui/plugins/create/create_video.py
+++ b/client/ayon_comfyui/plugins/create/create_video.py
@@ -22,9 +22,9 @@ class VideoCreator(Creator):
     this publish.
     """
 
-    identifier = "review"
+    identifier = "render"
     label = "AI Video"
-    product_base_type = "review"
+    product_base_type = "render"
     product_type = product_base_type
     description = "Video generated using ComfyUI"
 

--- a/client/ayon_comfyui/plugins/create/create_workfile.py
+++ b/client/ayon_comfyui/plugins/create/create_workfile.py
@@ -4,7 +4,7 @@ from ayon_comfyui.api.plugin import ComfyUIAutoCreator
 
 
 class CreateWorkfile(ComfyUIAutoCreator):
-    identifier = "workfile"
+    identifier = "io.ayon.creators.comfyui.workfile"
     label = "Workfile"
     product_type = "workfile"
 

--- a/client/ayon_comfyui/plugins/publish/collect_video.py
+++ b/client/ayon_comfyui/plugins/publish/collect_video.py
@@ -43,7 +43,7 @@ class CollectVideo(pyblish.api.InstancePlugin):
     order = pyblish.api.CollectorOrder + 0.16
     label = "Collect Generated Video + Thumbnail"
     hosts = ["comfyui"]
-    families = ["review"]
+    families = ["render"]
 
     default_variant = "Main"
 

--- a/client/ayon_comfyui/plugins/publish/collect_video.py
+++ b/client/ayon_comfyui/plugins/publish/collect_video.py
@@ -43,7 +43,7 @@ class CollectVideo(pyblish.api.InstancePlugin):
     order = pyblish.api.CollectorOrder + 0.16
     label = "Collect Generated Video + Thumbnail"
     hosts = ["comfyui"]
-    families = ["video"]
+    families = ["review"]
 
     default_variant = "Main"
 


### PR DESCRIPTION
This PR changes `video` product type in favor of `review` product type.
`video` is not supported by vanilla ayon-core which leads to publishes not including these.

I chose `review` only because atm comfy can only publish container formats (mp4) and it felt the most fitting.
Another option would be `render` but imho this should rather be used for image sequences that can run through `Extract Review` if so desired.