### PR TITLE
Publish as AYON reviewable

### DIFF
--- a/client/ayon_comfyui/plugins/publish/collect_image.py
+++ b/client/ayon_comfyui/plugins/publish/collect_image.py
@@ -59,11 +59,11 @@ class CollectImage(pyblish.api.InstancePlugin):
 
         instance.context.data["currentFile"] = files[0]
 
-        # With publishing just one file, there's a tendency
-        # for Comfy to cache the results in the browser
-
         if len(files) == 1:
             files = files[0]
+
+        # marking instance as reviewable
+        instance.data["review"] = True
 
         # creating representation
         instance.data["representations"].append(
@@ -72,11 +72,11 @@ class CollectImage(pyblish.api.InstancePlugin):
                 "ext": ext[1:],
                 "files": files,
                 "stagingDir": staging_dir,
-                "tags": ["webreview"],
+                "tags": ["review"],
             }
         )
 
-        # Maybe use PIL to generate a tiled image
+        # NOTE(@sas): Maybe generate a tiled image for batched images
 
         thumbnail_img = files
         if isinstance(thumbnail_img, list):

--- a/client/ayon_comfyui/plugins/publish/collect_image.py
+++ b/client/ayon_comfyui/plugins/publish/collect_image.py
@@ -72,6 +72,7 @@ class CollectImage(pyblish.api.InstancePlugin):
                 "ext": ext[1:],
                 "files": files,
                 "stagingDir": staging_dir,
+                "tags": ["webreview"],
             }
         )
 

--- a/client/ayon_comfyui/plugins/publish/collect_image.py
+++ b/client/ayon_comfyui/plugins/publish/collect_image.py
@@ -59,11 +59,12 @@ class CollectImage(pyblish.api.InstancePlugin):
 
         instance.context.data["currentFile"] = files[0]
 
-        # With publishing just one file, there's a tendency
-        # for Comfy to cache the results in the browser
-
         if len(files) == 1:
             files = files[0]
+
+        # marking instance as reviewable
+        instance.data["review"] = True
+        instance.data["families"].append("review")
 
         # creating representation
         instance.data["representations"].append(
@@ -72,11 +73,11 @@ class CollectImage(pyblish.api.InstancePlugin):
                 "ext": ext[1:],
                 "files": files,
                 "stagingDir": staging_dir,
-                "tags": ["webreview"],
+                "tags": ["review"],
             }
         )
 
-        # Maybe use PIL to generate a tiled image
+        # NOTE(@sas): Maybe generate a tiled image for batched images
 
         thumbnail_img = files
         if isinstance(thumbnail_img, list):

--- a/client/ayon_comfyui/plugins/publish/collect_video.py
+++ b/client/ayon_comfyui/plugins/publish/collect_video.py
@@ -124,6 +124,10 @@ class CollectVideo(pyblish.api.InstancePlugin):
 
         instance.context.data["currentFile"] = video_info.video_file
 
+        # marking instance as reviewable
+        instance.data["review"] = True
+        instance.data["families"].append("review")
+
         # creating representation
         instance.data["representations"].append(
             {
@@ -131,7 +135,7 @@ class CollectVideo(pyblish.api.InstancePlugin):
                 "ext": video_info.video_extension[1:],
                 "files": video_info.video_file,
                 "stagingDir": staging_dir,
-                "tags": ["webreview"],
+                "tags": ["review"],
             }
         )
 

--- a/client/ayon_comfyui/plugins/publish/collect_video.py
+++ b/client/ayon_comfyui/plugins/publish/collect_video.py
@@ -124,6 +124,9 @@ class CollectVideo(pyblish.api.InstancePlugin):
 
         instance.context.data["currentFile"] = video_info.video_file
 
+        # marking instance as reviewable
+        instance.data["review"] = True
+
         # creating representation
         instance.data["representations"].append(
             {
@@ -131,7 +134,7 @@ class CollectVideo(pyblish.api.InstancePlugin):
                 "ext": video_info.video_extension[1:],
                 "files": video_info.video_file,
                 "stagingDir": staging_dir,
-                "tags": ["webreview"],
+                "tags": ["review"],
             }
         )
 

--- a/client/ayon_comfyui/plugins/publish/collect_video.py
+++ b/client/ayon_comfyui/plugins/publish/collect_video.py
@@ -131,6 +131,7 @@ class CollectVideo(pyblish.api.InstancePlugin):
                 "ext": video_info.video_extension[1:],
                 "files": video_info.video_file,
                 "stagingDir": staging_dir,
+                "tags": ["webreview"],
             }
         )
 


### PR DESCRIPTION
This PR adds `webreview` tag to image/review products in order to automatically upload them to AYON as a reviewable representation.

Since this addon exclusively supports AYON web-reviewable media (png, mp4, webm) i think it's safe to always add the tag.