### PR TITLE
Creators: Remove AI prefix from labels

### DIFF
--- a/client/ayon_comfyui/plugins/create/create_image.py
+++ b/client/ayon_comfyui/plugins/create/create_image.py
@@ -22,7 +22,7 @@ class ImageCreator(Creator):
     """
 
     identifier = "io.ayon.creators.comfyui.image"
-    label = "AI Image"
+    label = "Image"
     product_type = "image"
     product_base_type = "image"
     description = "Image generated using ComfyUI"

--- a/client/ayon_comfyui/plugins/create/create_model.py
+++ b/client/ayon_comfyui/plugins/create/create_model.py
@@ -23,7 +23,7 @@ class ModelCreator(Creator):
     """
 
     identifier = "io.ayon.creators.comfyui.model"
-    label = "AI 3D Model"
+    label = "3D Model"
     product_type = "model"
     product_base_type = "model"
     description = "ComfyUI generated model."

--- a/client/ayon_comfyui/plugins/create/create_video.py
+++ b/client/ayon_comfyui/plugins/create/create_video.py
@@ -23,7 +23,7 @@ class VideoCreator(Creator):
     """
 
     identifier = "io.ayon.creators.comfyui.render"
-    label = "AI Video"
+    label = "Video"
     product_base_type = "render"
     product_type = product_base_type
     description = "Video generated using ComfyUI"


### PR DESCRIPTION
## Changelog Description

No need to prefix label with AI - because ComfyUI *may* generate it through other means as well and it's just overly labeling everything.

## Additional review information

Cosmetics really.

## Testing notes:

1. ...
