### PR TITLE
Settings: Add Creators + support product base types (aliases)

### DIFF
--- a/client/ayon_comfyui/api/plugin.py
+++ b/client/ayon_comfyui/api/plugin.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import ayon_api
-from ayon_core.pipeline import AutoCreator, CreatedInstance, LoaderPlugin
+from ayon_core.pipeline import (
+    AutoCreator,
+    CreatedInstance,
+    Creator,
+    LoaderPlugin
+)
 
 if TYPE_CHECKING:
     from ayon_core.pipeline.create.context import CreateContext
@@ -14,9 +19,15 @@ from ayon_comfyui.api.pipeline import list_instances
 from ayon_comfyui.api.qt_rpc import QRPCManager, RPCStub
 
 
-# Adapting from Photoshop
+class ComfyUICreator(Creator):
+    skip_discovery = True
+    settings_category = "comfyui"
+
+
 class ComfyUIAutoCreator(AutoCreator):
     """Generic ComfyUI autocreator to extend."""
+    skip_discovery = True
+    settings_category = "comfyui"
 
     def get_instance_attr_defs(self):
         return []

--- a/client/ayon_comfyui/plugins/create/create_image.py
+++ b/client/ayon_comfyui/plugins/create/create_image.py
@@ -9,12 +9,13 @@ if TYPE_CHECKING:
 
 from ayon_comfyui.api.pipeline import list_instances
 from ayon_comfyui.api.qt_rpc import QRPCManager
+from ayon_comfyui.api.plugin import ComfyUICreator
 from ayon_core.lib import BoolDef, NumberDef, TextDef
-from ayon_core.pipeline import CreatedInstance, Creator, CreatorError
+from ayon_core.pipeline import CreatedInstance, CreatorError
 from ayon_core.pipeline.create import PRODUCT_NAME_ALLOWED_SYMBOLS
 
 
-class ImageCreator(Creator):
+class CreateImage(ComfyUICreator):
     """Creator for image(s) before publishing.
 
     On create, spawn a node that is to be associated with
@@ -27,7 +28,6 @@ class ImageCreator(Creator):
     product_base_type = "image"
     description = "Image generated using ComfyUI"
 
-    default_variant = "Main"
     default_img_name = "ayon"
 
     icon = "gears"

--- a/client/ayon_comfyui/plugins/create/create_model.py
+++ b/client/ayon_comfyui/plugins/create/create_model.py
@@ -10,12 +10,13 @@ if TYPE_CHECKING:
 from ayon_comfyui.api.pipeline import list_instances
 from ayon_comfyui.api.qt_rpc import QRPCManager
 from ayon_comfyui.api.rpc_stub import PublishType
+from ayon_comfyui.api.plugin import ComfyUICreator
 from ayon_core.lib import BoolDef, EnumDef, TextDef
-from ayon_core.pipeline import CreatedInstance, Creator, CreatorError
+from ayon_core.pipeline import CreatedInstance, CreatorError
 from ayon_core.pipeline.create import PRODUCT_NAME_ALLOWED_SYMBOLS
 
 
-class ModelCreator(Creator):
+class CreateModel(ComfyUICreator):
     """Creator for model before publishing.
 
     On create, spawn a node that is to be associated with
@@ -26,9 +27,8 @@ class ModelCreator(Creator):
     label = "AI 3D Model"
     product_type = "model"
     product_base_type = "model"
-    description = "ComfyUI generated model."
+    description = "ComfyUI generated model"
 
-    default_variant = "Main"
     default_vid_name = "ayon"
 
     enum_fallback_format: ClassVar[dict] = {

--- a/client/ayon_comfyui/plugins/create/create_video.py
+++ b/client/ayon_comfyui/plugins/create/create_video.py
@@ -10,12 +10,13 @@ if TYPE_CHECKING:
 from ayon_comfyui.api.pipeline import list_instances
 from ayon_comfyui.api.qt_rpc import QRPCManager
 from ayon_comfyui.api.rpc_stub import PublishType
+from ayon_comfyui.api.plugin import ComfyUICreator
 from ayon_core.lib import BoolDef, EnumDef, NumberDef, TextDef
-from ayon_core.pipeline import CreatedInstance, Creator, CreatorError
+from ayon_core.pipeline import CreatedInstance, CreatorError
 from ayon_core.pipeline.create import PRODUCT_NAME_ALLOWED_SYMBOLS
 
 
-class VideoCreator(Creator):
+class CreateVideo(ComfyUICreator):
     """Creator for video before publishing.
 
     On create, spawn a node that is to be associated with
@@ -28,7 +29,6 @@ class VideoCreator(Creator):
     product_type = product_base_type
     description = "Video generated using ComfyUI"
 
-    default_variant = "Main"
     default_vid_name = "ayon"
 
     icon = "gears"

--- a/server/creators.py
+++ b/server/creators.py
@@ -1,0 +1,76 @@
+import re
+from pydantic import validator
+
+from ayon_server.exceptions import BadRequestException
+from ayon_server.settings import (
+    BaseSettingsModel,
+    SettingsField,
+)
+
+
+class ProductTypeItemModel(BaseSettingsModel):
+    _layout = "compact"
+    product_type: str = SettingsField(
+        title="Product type",
+        description="Product type name",
+    )
+    label: str = SettingsField(
+        "",
+        title="Label",
+        description="Label to display in UI for the product type",
+    )
+
+
+class BasicCreatorModel(BaseSettingsModel):
+    enabled: bool = SettingsField(
+        True,
+        title="Enabled"
+    )
+    default_variants: list[str] = SettingsField(
+        default_factory=list,
+        title="Default Variants"
+    )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types that this plugin can create."
+        ),
+    )
+
+    @staticmethod
+    def is_valid_variant(variant: str) -> bool:
+        return re.fullmatch(r'[A-Za-z0-9_]+', variant)  # alphanumeric
+
+    @validator("default_variants")
+    def valid_variants(cls, value):
+        for variant in value:
+            if not cls.is_valid_variant(variant):
+                raise BadRequestException(
+                    f"Invalid characters in variant name {variant}. "
+                    "Allowed characters are A-Za-z0-9_"
+                )
+        return value
+
+
+class CreatorsModel(BaseSettingsModel):
+
+    CreateImage: BasicCreatorModel = SettingsField(
+        default_factory=BasicCreatorModel,
+        title="Create Image"
+    )
+    CreateModel: BasicCreatorModel = SettingsField(
+        default_factory=BasicCreatorModel,
+        title="Create Model"
+    )
+    CreateVideo: BasicCreatorModel = SettingsField(
+        default_factory=BasicCreatorModel,
+        title="Create Video"
+    )
+
+
+DEFAULT_CREATORS_SETTINGS = {
+    "CreateImage": {"default_variants": ["Main"], "enabled": True},
+    "CreateModel": {"default_variants": ["Main"], "enabled": True},
+    "CreateVideo": {"default_variants": ["Main"], "enabled": True},
+}

--- a/server/settings.py
+++ b/server/settings.py
@@ -8,8 +8,11 @@ from ayon_server.settings import BaseSettingsModel, SettingsField
 
 from .local_settings import ComfyLocalSettings
 from .remote_settings import ComfyRemoteSettings
+from .creators import CreatorsModel, DEFAULT_CREATORS_SETTINGS
+
 
 COMFY_DEFAULT_VALUES: dict[str, Any] = {
+    "create": DEFAULT_CREATORS_SETTINGS,
     "local_settings": {"local_setting_list": []},
     "remote_settings": {"remote_setting_list": []},
 }
@@ -27,3 +30,6 @@ class ComfyUISettings(BaseSettingsModel):
         default_factory=ComfyRemoteSettings,
         title="ComfyUI remote launch options",
     )
+
+    create: CreatorsModel = SettingsField(
+        default_factory=CreatorsModel, title="Creators")


### PR DESCRIPTION
## Changelog Description

- Allow enabling/disabling creators
- Support product type items (product type aliases)

## Additional review information

Adds settings.

## Testing notes:

1. Creators should still work
