### PR TITLE
Local IP instead of localhost

### DIFF
--- a/client/ayon_comfyui/_comfyui_plugin/ayon_menu/js/lib/consts.js
+++ b/client/ayon_comfyui/_comfyui_plugin/ayon_menu/js/lib/consts.js
@@ -1,1 +1,1 @@
-export const AYON_ORIGIN_ADRESS = "http://localhost:5454";
+export const AYON_ORIGIN_ADRESS = "http://127.0.0.1:5454";

--- a/client/ayon_comfyui/_comfyui_plugin/ayon_menu/ws_server.py
+++ b/client/ayon_comfyui/_comfyui_plugin/ayon_menu/ws_server.py
@@ -30,4 +30,4 @@ def run_server():
     app = web.Application()
     app.router.add_get("/ws", ws_handler)
 
-    web.run_app(app, host="localhost", port=AYON_BACKEND_PORT)
+    web.run_app(app, host="127.0.0.1", port=AYON_BACKEND_PORT)

--- a/client/ayon_comfyui/api/iframe/static_server.py
+++ b/client/ayon_comfyui/api/iframe/static_server.py
@@ -59,9 +59,9 @@ class StaticServerThread(Thread):
     async def async_run(self):
         runner = web.AppRunner(self._app)
         await runner.setup()
-        site = web.TCPSite(runner, "localhost", self.port)
+        site = web.TCPSite(runner, "127.0.0.1", self.port)
         await site.start()
-        print(f"Static Server running on http://localhost:{self.port}")
+        print(f"Static Server running on http://127.0.0.1:{self.port}")
 
         # Shutdown conditional
         await self._shutdown_event.wait()

--- a/client/ayon_comfyui/api/launch_logic.py
+++ b/client/ayon_comfyui/api/launch_logic.py
@@ -335,7 +335,7 @@ def launch_local(
     try:
         rpcman = QRPCManager(
             parent=app,
-            client_hostname="localhost",
+            client_hostname="127.0.0.1",
             client_port=settings.port_backend,
             server_port=settings.port_webui,
             static_port=settings.port_static_frontend,

--- a/client/ayon_comfyui/api/qt_rpc.py
+++ b/client/ayon_comfyui/api/qt_rpc.py
@@ -40,7 +40,7 @@ class QRPCManager(QObject, QThread_interface):
         self,
         *,
         parent: QObject = None,
-        client_hostname: str = "localhost",
+        client_hostname: str = "127.0.0.1",
         client_port: int | str = 55055,
         server_port: int | str = 55056,
         static_port: int | str = 5454,

--- a/client/ayon_comfyui/api/rpc_server.py
+++ b/client/ayon_comfyui/api/rpc_server.py
@@ -97,7 +97,7 @@ def pull_origin_from_settings() -> str:
         return profile.address_frontend
     if isinstance(settings, ComfyLocalSettings):
         return settings.address_frontend
-    return "http://localhost:5454"
+    return "http://127.0.0.1:5454"
 
 
 def get_client_from_origin(origin: str) -> WSRPCBase | None:
@@ -225,10 +225,10 @@ class RPCServerThread(Thread):
         """Run server async."""
         runner = aiohttp.web.AppRunner(self._app)
         await runner.setup()
-        site = aiohttp.web.TCPSite(runner, "localhost", self._port)
+        site = aiohttp.web.TCPSite(runner, "127.0.0.1", self._port)
         await site.start()
         log.info(
-            f"Websocket Server running on ws://localhost:{self._port}/ws/"  # noqa: G004
+            f"Websocket Server running on ws://127.0.0.1:{self._port}/ws/"  # noqa: G004
         )
 
         # Shutdown conditional

--- a/client/ayon_comfyui/api/rpc_stub.py
+++ b/client/ayon_comfyui/api/rpc_stub.py
@@ -55,7 +55,7 @@ class RPCClientStub:  # noqa: PLR0904
 
     # Static site hosting iframe.
     # TODO(@sas): retrieve from url settings
-    origin: str = "http://localhost:5454"
+    origin: str = "http://127.0.0.1:5454"
 
     def __init__(self):  # noqa: D107
         self.__class__.origin = pull_origin_from_settings()

--- a/client/ayon_comfyui/api/ws_client.py
+++ b/client/ayon_comfyui/api/ws_client.py
@@ -24,7 +24,7 @@ class WSClientThread(Thread):
 
     def __init__(  # noqa: D107
         self,
-        hostname: str = "localhost",
+        hostname: str = "127.0.0.1",
         port: int | str = 55055,
         use_https: bool = False,  # noqa: FBT001, FBT002
         retries: int = 3,

--- a/client/ayon_comfyui/settings_util/parse_settings.py
+++ b/client/ayon_comfyui/settings_util/parse_settings.py
@@ -371,7 +371,7 @@ class ComfyLocalSettings:
     @property
     def address_frontend(self) -> str:
         """Return static frontend adress."""
-        return f"http://localhost:{self.port_static_frontend}"
+        return f"http://127.0.0.1:{self.port_static_frontend}"
 
     @property
     def profiles(self) -> list[str]:
@@ -469,7 +469,7 @@ class ComfyRemoteSettings:
                 self.comfy_url, timeout=1
             )
 
-            static_origin = f"http://localhost:{self.port_static_frontend}"
+            static_origin = f"http://127.0.0.1:{self.port_static_frontend}"
 
             if is_available:
                 logs.append(
@@ -549,7 +549,7 @@ class ComfyRemoteSettings:
         @property
         def address_frontend(self) -> str:
             """Return static frontend adress."""
-            return f"http://localhost:{self.port_static_frontend}"
+            return f"http://127.0.0.1:{self.port_static_frontend}"
 
         @property
         def comfy_url(self) -> str:
@@ -573,7 +573,7 @@ class ComfyRemoteSettings:
         @property
         def netloc_webui(self) -> str:
             """Return netloc of webui."""
-            url = urlparse(self.comfy_url)._replace(netloc="localhost")
+            url = urlparse(self.comfy_url)._replace(netloc="127.0.0.1")
             url = ComfyRemoteSettings.url_specify_port(url, self.port_webui)
             return urlparse(url).netloc
 

--- a/server/remote_settings.py
+++ b/server/remote_settings.py
@@ -42,12 +42,12 @@ class ComfyRemoteSetting(BaseSettingsModel):
     )
 
     comfy_web_adress: str = SettingsField(
-        default="http://localhost:8188",
+        default="http://127.0.0.1:8188",
         title="ComfyUI Web Address",
         description=(
             "Web address of the frontend. On localhost, "
             "ComfyUI runs on port 8188, so the address would be "
-            "'http://localhost:8188'. If comfyui is on the web, "
+            "'http://127.0.0.1:8188'. If comfyui is on the web, "
             "use something like 'https://comfyui.contoso.com'."
         ),
     )


### PR DESCRIPTION
## Changelog Description
This PR changes every code occurrence of `localhost` to `127.0.0.1` in order to support comfy version `>=0.19.0`.

## Additional review information
When I noticed the bug i naively tried out `http://127.0.0.1:8484` manually and it worked.
Went ahead and set up this PR which seems to do the trick but to be honest I have no clue why this works :/
Tested versions:
- `0.19.0`
- `0.19.1`
- `0.20.1`
- `0.22.0`


## Testing notes:
1. configure local launch profile with any comfy version `>=0.19.0`
2. run comfy
3. confirm the auto-opened adress is `http://127.0.0.1:8484`
4. test AYON integrations, they should be working again


refs https://github.com/ynput/ayon-comfyui/issues/29