### PR TITLE
Patch: Loader product filters

### DIFF
--- a/client/ayon_comfyui/plugins/load/load_image.py
+++ b/client/ayon_comfyui/plugins/load/load_image.py
@@ -6,6 +6,9 @@ import os
 from typing import ClassVar
 
 import clique
+
+from ayon_core.lib.transcoding import IMAGE_EXTENSIONS
+
 from ayon_comfyui.api.pipeline import containerise
 from ayon_comfyui.api.plugin import ComfyUILoader
 from ayon_comfyui.api.upload_util import upload_input_images
@@ -14,8 +17,9 @@ from ayon_comfyui.api.upload_util import upload_input_images
 class ImageLoader(ComfyUILoader):
     """Load images."""
 
-    product_types: ClassVar[set[str]] = {"image", "render", "plate"}
+    product_types: ClassVar[set[str]] = {"*"}
     representations: ClassVar[set[str]] = {"*"}
+    extensions: ClassVar[set[str]] = {ext.lstrip(".") for ext in IMAGE_EXTENSIONS}
     label = "Load image(s) into current graph."
     icon = "image"
     order = -10
@@ -35,6 +39,9 @@ class ImageLoader(ComfyUILoader):
             namespace (str, optional): Use pre-defined namespace
             options (dict, optional): Additional settings dictionary
         """
+        self.log.info(f"{IMAGE_EXTENSIONS = }")
+        self.log.info(f"{context = }")
+        self.log.info(f"{options = }")
         # Retrieve filepath
         filepaths = self.expand_files_if_sequence(context)
         self.log.debug(filepaths)
@@ -54,6 +61,7 @@ class ImageLoader(ComfyUILoader):
             image_upload_info=image_upload_info,
             loader=self.__class__.__name__,
         )
+        self.log.info(f"{container = }")
 
         # Create the image loader node with the data on it.
         self.stub.create_load_node(container)

--- a/client/ayon_comfyui/plugins/load/load_image.py
+++ b/client/ayon_comfyui/plugins/load/load_image.py
@@ -14,7 +14,7 @@ from ayon_comfyui.api.upload_util import upload_input_images
 class ImageLoader(ComfyUILoader):
     """Load images."""
 
-    product_types: ClassVar[set[str]] = {"image", "render"}
+    product_types: ClassVar[set[str]] = {"image", "render", "plate"}
     representations: ClassVar[set[str]] = {"*"}
     label = "Load image(s) into current graph."
     icon = "image"

--- a/client/ayon_comfyui/plugins/load/load_image.py
+++ b/client/ayon_comfyui/plugins/load/load_image.py
@@ -19,7 +19,9 @@ class ImageLoader(ComfyUILoader):
 
     product_types: ClassVar[set[str]] = {"*"}
     representations: ClassVar[set[str]] = {"*"}
-    extensions: ClassVar[set[str]] = {ext.lstrip(".") for ext in IMAGE_EXTENSIONS}
+    extensions: ClassVar[set[str]] = {
+        ext.lstrip(".") for ext in IMAGE_EXTENSIONS
+    }
     label = "Load image(s) into current graph."
     icon = "image"
     order = -10

--- a/client/ayon_comfyui/plugins/load/load_image.py
+++ b/client/ayon_comfyui/plugins/load/load_image.py
@@ -41,9 +41,6 @@ class ImageLoader(ComfyUILoader):
             namespace (str, optional): Use pre-defined namespace
             options (dict, optional): Additional settings dictionary
         """
-        self.log.info(f"{IMAGE_EXTENSIONS = }")
-        self.log.info(f"{context = }")
-        self.log.info(f"{options = }")
         # Retrieve filepath
         filepaths = self.expand_files_if_sequence(context)
         self.log.debug(filepaths)
@@ -63,7 +60,6 @@ class ImageLoader(ComfyUILoader):
             image_upload_info=image_upload_info,
             loader=self.__class__.__name__,
         )
-        self.log.info(f"{container = }")
 
         # Create the image loader node with the data on it.
         self.stub.create_load_node(container)

--- a/client/ayon_comfyui/plugins/load/load_video.py
+++ b/client/ayon_comfyui/plugins/load/load_video.py
@@ -20,7 +20,9 @@ class VideoLoader(ComfyUILoader):
 
     product_types: ClassVar[set[str]] = {"*"}
     representations: ClassVar[set[str]] = {"*"}
-    extensions: ClassVar[set[str]] = {ext.lstrip(".") for ext in VIDEO_EXTENSIONS}
+    extensions: ClassVar[set[str]] = {
+        ext.lstrip(".") for ext in VIDEO_EXTENSIONS
+    }
     label = "Load video into current graph."
     icon = "image"
     order = -10.1

--- a/client/ayon_comfyui/plugins/load/load_video.py
+++ b/client/ayon_comfyui/plugins/load/load_video.py
@@ -15,7 +15,7 @@ from ayon_comfyui.api.upload_util import upload_input_images
 class VideoLoader(ComfyUILoader):
     """Load video."""
 
-    product_types: ClassVar[set[str]] = {"video"}
+    product_types: ClassVar[set[str]] = {"render", "plate", "prerender"}
     representations: ClassVar[set[str]] = {"mp4", "mov", "webm"}
     label = "Load video into current graph."
     icon = "image"

--- a/client/ayon_comfyui/plugins/load/load_video.py
+++ b/client/ayon_comfyui/plugins/load/load_video.py
@@ -6,6 +6,9 @@ import os
 from typing import ClassVar
 
 import clique
+
+from ayon_core.lib.transcoding import VIDEO_EXTENSIONS
+
 from ayon_comfyui.api.pipeline import containerise
 from ayon_comfyui.api.plugin import ComfyUILoader
 from ayon_comfyui.api.rpc_stub import LoadType
@@ -15,8 +18,9 @@ from ayon_comfyui.api.upload_util import upload_input_images
 class VideoLoader(ComfyUILoader):
     """Load video."""
 
-    product_types: ClassVar[set[str]] = {"render", "plate", "prerender"}
-    representations: ClassVar[set[str]] = {"mp4", "mov", "webm"}
+    product_types: ClassVar[set[str]] = {"*"}
+    representations: ClassVar[set[str]] = {"*"}
+    extensions: ClassVar[set[str]] = {ext.lstrip(".") for ext in VIDEO_EXTENSIONS}
     label = "Load video into current graph."
     icon = "image"
     order = -10.1


### PR DESCRIPTION
## Changelog Description
This PR replaces non-standard `video` product type in `VideoLoader` and adds `plate` to supported roduct types for `ImageLoader`.

## Additional review information
Originally I wanted to use `ayon_core.lib.transcoding.IMAGE_EXTENSIONS` and `VIDEO_EXTENSIONS` but noticed that `ayon_core` can't be imported in plugins.
