### PR TITLE
disable handle_signals when running the webserver on a subthread

### DIFF
--- a/client/ayon_comfyui/_comfyui_plugin/ayon_menu/ws_server.py
+++ b/client/ayon_comfyui/_comfyui_plugin/ayon_menu/ws_server.py
@@ -30,4 +30,10 @@ def run_server():
     app = web.Application()
     app.router.add_get("/ws", ws_handler)
 
-    web.run_app(app, host="127.0.0.1", port=AYON_BACKEND_PORT)
+    web.run_app(
+        app,
+        host="127.0.0.1",
+        port=AYON_BACKEND_PORT,
+        # Python only allows signal handling from the main thread on Unix/Linux
+        handle_signals=False,
+    )


### PR DESCRIPTION
## Changelog Description
changed `handle_signals` to `False` when running the webserver on a subthread on unix systems

## Additional review information

Error Message:
```
Exception in thread Thread-1 (run_server):
Traceback (most recent call last):
  File "/usr/lib64/python3.13/asyncio/unix_events.py", line 107, in add_signal_handler
    signal.set_wakeup_fd(self._csock.fileno())
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
ValueError: set_wakeup_fd only works in main thread of the main interpreter

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.13/threading.py", line 1044, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/usr/lib64/python3.13/threading.py", line 995, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/ComfyUI/custom_nodes/ayon_menu/ws_server.py", line 33, in run_server
    web.run_app(app, host="127.0.0.1", port=AYON_BACKEND_PORT)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib64/python3.13/site-packages/aiohttp/web.py", line 517, in run_app
    loop.run_until_complete(main_task)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib64/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
RuntimeError: set_wakeup_fd only works in main thread of the main interpreter
Starting server
```

similar issue: https://stackoverflow.com/questions/62671883/discordbot-using-threading-raise-runtimeerror-set-wakeup-fd-only-works-in-main
works fine on windows but raises same error on linux

https://stackoverflow.com/a/71131833 and this thread, related to the same topic (running an `aiohttp` webserver on a secondary thread, recommends setting `handle_signals=False`.

additional info:
https://docs.aiohttp.org/en/stable/web_reference.html#aiohttp.web.run_app
(same file: `aiohttp.web.AppRunner` and `aiohttp.web.ServerRunner` default to `handle_signals=False`)


## Testing notes:
1. start with this step
2. follow this step
