### PR TITLE
new: format error message using html and include stacktrace

### DIFF
--- a/client/ayon_comfyui/api/deduce_python.py
+++ b/client/ayon_comfyui/api/deduce_python.py
@@ -111,6 +111,28 @@ def venv_check_existence(environment_path: Path) -> bool:
     return all(asserts)
 
 
+def format_error_message(
+    stderr: str,
+    message: str = "Something went wrong.",
+    args: list[str | Path] | None = None
+) -> ChildProcessError:
+    code_block_style = (
+        "background: #1e1e1e;"
+        "color: #dcdcdc;"
+        "white-space: pre-wrap;"  # allow word wrapping in code blocks
+    )
+
+    text = f"<p>{message}</p>"
+    if args:
+        text += "<p>Args:</p>"
+        text += f"<pre style='{code_block_style}'>{args}</pre>"
+    if stderr:
+        text += "<p>Output:</p>"
+        text += f"<pre style='{code_block_style}'>{stderr}</pre>"
+
+    return ChildProcessError(text)
+
+
 def pip_install_requirements(
     python_exec_path: Path, requirements_path: Path
 ) -> None:
@@ -147,24 +169,11 @@ def pip_install_requirements(
     out, err = out.strip(), err.strip()
 
     if "Error" in out or "ERROR" in out or "Error" in err or "ERROR" in err:
-
-        code_block_style = (
-            "background: #1e1e1e;"
-            "color: #dcdcdc;"
+        error = format_error_message(
+            stderr=err,
+            message="Failed to install packages from requirements.",
+            args=args,
         )
-
-        error = ChildProcessError(
-            "<p>Failed to install packages from requirements.</p>"
-            "<p>Args:</p>"
-            f"<pre style='{code_block_style}'>{args}</pre>"
-            "<p>Output:</p>"
-            f"<pre style='{code_block_style}'>{err}</pre>"
-        )
-        # error.add_note(
-        #     "Failed to install packages from requirements. "
-        #     "Try manually installing them with "
-        #     f"{python_exec_path} -m pip instal -r {requirements_path}"
-        # )
         raise error
 
 
@@ -199,10 +208,11 @@ def python_setup_venv_with_depends(
         out, err = proc.communicate()
         out, err = out.strip(), err.strip()
         if out or err:
-            error = ChildProcessError(
-                "Failed to set up a virtual environment."
+            error = format_error_message(
+                stderr=err,
+                message="Failed to set up a virtual environment.",
+                args=venv_args,
             )
-            # error.add_note("Failed to set up a virtual environment.")
             raise error
 
     venv_python = venv_get_python(environment_path)

--- a/client/ayon_comfyui/api/deduce_python.py
+++ b/client/ayon_comfyui/api/deduce_python.py
@@ -119,7 +119,6 @@ def format_error_message(
     code_block_style = (
         "background: #1e1e1e;"
         "color: #dcdcdc;"
-        "white-space: pre-wrap;"  # allow word wrapping in code blocks
     )
 
     text = f"<p>{message}</p>"

--- a/client/ayon_comfyui/api/deduce_python.py
+++ b/client/ayon_comfyui/api/deduce_python.py
@@ -147,8 +147,18 @@ def pip_install_requirements(
     out, err = out.strip(), err.strip()
 
     if "Error" in out or "ERROR" in out or "Error" in err or "ERROR" in err:
+
+        code_block_style = (
+            "background: #1e1e1e;"
+            "color: #dcdcdc;"
+        )
+
         error = ChildProcessError(
-            "Failed to install packages from requirements."
+            "<p>Failed to install packages from requirements.</p>"
+            "<p>Args:</p>"
+            f"<pre style='{code_block_style}'>{args}</pre>"
+            "<p>Output:</p>"
+            f"<pre style='{code_block_style}'>{err}</pre>"
         )
         # error.add_note(
         #     "Failed to install packages from requirements. "

--- a/client/ayon_comfyui/api/launch_logic.py
+++ b/client/ayon_comfyui/api/launch_logic.py
@@ -123,17 +123,21 @@ def _subproc_launch_ComfyUI() -> subprocess.Popen:
                     pythonpath, env_path, requirements
                 )
             except ChildProcessError as e:
+
+                lines = [
+                    "<p>Couldn't instantiate virtual environment using:</p>",
+                    f"<p>python: <code>{pythonpath!s}</code></p>",
+                    f"<p>goal environment folder: <code>{env_path!s}</code></p>",  # noqa: E501
+                    f"<p>requirements: <code>{requirements!s}</code></p>",
+                    f"Error: {e}",
+                    "Process will now shut down.",
+                ]
+                message = "".join(lines)
+
                 show_message_dialog(
-                    "Virtual environment error",
-                    (
-                        "Couldn't instantiate virtual environment using:\n"
-                        f"python: {pythonpath!s}\n"
-                        f"goal environment folder: {env_path!s}\n"
-                        f"requirements: {requirements!s}\n\n"
-                        f"Error: {e}\n\n"
-                        "Process will now shut down."
-                    ),
-                    "critical",
+                    title="Virtual environment error",
+                    message=message,
+                    level="critical",
                 )
                 return None
         else:

--- a/client/ayon_comfyui/api/launch_logic.py
+++ b/client/ayon_comfyui/api/launch_logic.py
@@ -20,7 +20,8 @@ from typing import TYPE_CHECKING
 from ayon_core.lib import env_value_to_bool
 from ayon_core.pipeline import get_current_project_name, install_host
 from ayon_core.tools.utils import get_ayon_qt_app
-from ayon_core.tools.utils.dialogs import show_message_dialog
+from ayon_core.tools.utils.dialogs import show_message_dialog, ScrollMessageBox
+from qtpy import QtWidgets
 
 if TYPE_CHECKING:
     from qtpy.QtWidgets import QApplication
@@ -124,21 +125,22 @@ def _subproc_launch_ComfyUI() -> subprocess.Popen:
                 )
             except ChildProcessError as e:
 
-                lines = [
-                    "<p>Couldn't instantiate virtual environment using:</p>",
-                    f"<p>python: <code>{pythonpath!s}</code></p>",
-                    f"<p>goal environment folder: <code>{env_path!s}</code></p>",  # noqa: E501
-                    f"<p>requirements: <code>{requirements!s}</code></p>",
-                    f"Error: {e}",
+                messages = [
+                    "<h1>Couldn't instantiate virtual environment</h1>",
+                    "Using:"
+                    f"python: <code>{pythonpath!s}</code>",
+                    f"target environment folder: <code>{env_path!s}</code>",
+                    f"requirements: <code>{requirements!s}</code>",
+                    "<h3>Error:</h3>",
+                    str(e),
                     "Process will now shut down.",
                 ]
-                message = "".join(lines)
-
-                show_message_dialog(
+                dialog = ScrollMessageBox(
+                    icon=QtWidgets.QMessageBox.Icon.Critical,
                     title="Virtual environment error",
-                    message=message,
-                    level="critical",
+                    messages=messages,
                 )
+                dialog.exec()
                 return None
         else:
             pythonpath = venv_get_python(env_path)


### PR DESCRIPTION
## Changelog Description
include the error message in the popup when comfyUI fails to launch

## Additional review information

This currently only catches `ChildProcessError` raised in `pip_install_requirements` and `python_setup_venv_with_depends`
So far, all other Errors have been logged in the process monitor.

## tbd:
Not sure if this is the Ideal solution... it might be better to redirect the `stderr` to the ayon process monitor and log any exceptions there.

## Testing notes:
1. setup a bad/invalid config or bad enviroment causing the comfyUI launch to 
2. attemptt to launch comfyui


### Example 1:
read only `local_env` folder

```bash
cd ~/dev/addons_resources/comfyui_envs

# delete any existing envs
rm -rf local_env   # or rename if you want to keep your envs

# remove write permissions
mkdir local_env
chmod a-w local_env 
```

<img width="567" height="483" alt="image" src="https://github.com/user-attachments/assets/9c12b4ae-9c91-4e92-84be-e7b7e4e9c591" />


### Example 2:
error during requirements install
(we could probably use a scroll area here)
<img width="541" height="1389" alt="image" src="https://github.com/user-attachments/assets/e20c8629-c32a-4d70-9c9d-8231ea5b0659" />



