### PR TITLE
Run comfy using server action and addon cli

### DIFF
--- a/client/ayon_comfyui/addon.py
+++ b/client/ayon_comfyui/addon.py
@@ -9,7 +9,9 @@ is shared between all hosts but, not documented at all.
 
 import os
 
-from ayon_core.addon import AYONAddon, IHostAddon
+from ayon_api import get_task_by_id, get_folder_by_id
+
+from ayon_core.addon import AYONAddon, IHostAddon, click_wrap
 
 from .version import __version__
 
@@ -42,6 +44,52 @@ class ComfyUIAddon(AYONAddon, IHostAddon):
         if app.host_name != self.host_name:
             return []
         return [os.path.join(COMFYUI_ADDON_ROOT, "hooks")]
+
+    def cli(self, addon_click_group) -> None:
+        main_group = click_wrap.group(
+            self._cli_main, name=self.name, help="Applications addon"
+        )
+        (
+            main_group.command(
+                self._cli_run_server,
+                name="run-server",
+                help="Run the ComfyUI server"
+            )
+            .option("--project-name", required=True, help="Project name")
+            .option("--entity-id", required=True, help="Entity id")
+        )
+        addon_click_group.add_command(
+            main_group.to_click_obj()
+        )
+
+    def _cli_main(self) -> None:
+        """Main CLI command."""
+        pass
+
+    def _cli_run_server(
+        self,
+        project_name: str = None,
+        entity_id: str = None,
+    ) -> None:
+        """Run server command."""
+        from .api.launch_logic import main
+
+        # differentiate between task and workfile
+        # --- on task i also prolly need to support `open last workfile`
+        task = get_task_by_id(
+            project_name, entity_id, fields=["name", "folderId"]
+        )
+        folder = get_folder_by_id(
+            project_name, task["folderId"], fields=["path"]
+        )
+        self.log.debug(f"{task = }, {folder = }")
+
+        # gotta prepare env for profile selector to find all required data
+        os.environ["AYON_PROJECT_NAME"] = project_name
+        os.environ["AYON_HOST_NAME"] = self.host_name  # needed?
+        os.environ["AYON_TASK_NAME"] = task["name"]
+        os.environ["AYON_FOLDER_PATH"] = folder["path"]
+        main()
 
 
 def get_launch_script_path() -> str:

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,8 +1,16 @@
 """Server package settings."""
 
-from typing import Type
+from typing import TYPE_CHECKING, List, Optional, Type
 
 from ayon_server.addons import BaseServerAddon
+from ayon_server.actions import SimpleActionManifest
+
+if TYPE_CHECKING:
+    from ayon_server.actions import (
+        ExecuteResponseModel,
+        ActionExecutor,
+    )
+
 
 from .settings import COMFY_DEFAULT_VALUES, ComfyUISettings
 
@@ -16,3 +24,83 @@ class ComfyUIAddon(BaseServerAddon):
         """Return default settings."""
         settings_model_cls = self.get_settings_model()
         return settings_model_cls(**COMFY_DEFAULT_VALUES)
+
+    async def get_simple_actions(
+        self,
+        project_name: Optional[str] = None,
+        variant: str = "production",
+    ) -> List["SimpleActionManifest"]:
+        return [
+            SimpleActionManifest(
+                order=1,
+                identifier="comfyui.launch",
+                label="Launch ComfyUI",
+                category="Applications",
+                entity_type="task",
+                allow_multiselection=False,
+                icon={
+                    "type": "material-symbols",
+                    "name": "terminal",
+                    "color": "#FF6600",
+                },
+            ),
+            SimpleActionManifest(
+                order=1,
+                identifier="comfyui.launch",
+                label="Launch ComfyUI",
+                category="Applications",
+                entity_type="workfile",
+                allow_multiselection=False,
+                icon={
+                    "type": "material-symbols",
+                    "name": "terminal",
+                    "color": "#FF66FF",
+                },
+            ),
+        ]
+
+    async def execute_action(
+        self, executor: "ActionExecutor"
+    ) -> "ExecuteResponseModel":
+        if executor.identifier != "comfyui.launch":
+            return await executor.get_simple_response(
+                message=(
+                    "Failed to launch ComfyUI. "
+                    "Unknown action identifier."
+                ),
+                success=False,
+            )
+
+        if executor.context.entity_type not in ["task", "workfile"]:
+            return await executor.get_simple_response(
+                message=(
+                    "Failed to launch ComfyUI. "
+                    "This action can only be executed on tasks or workfiles."
+                ),
+                success=False,
+            )
+
+        if len(executor.context.entity_ids) > 0:
+            return await executor.get_simple_response(
+                message=(
+                    "Failed to launch ComfyUI. "
+                    "This action cannot be executed on multiple entities."
+                ),
+                success=False,
+            )
+
+        # i think this is already handled automatically
+        # bundle_args: List[str] = []
+        # if executor.variant not in ("production", "staging"):
+        #     bundle_args = ["--bundle", executor.variant]
+
+        args = [
+            "addon", "comfyui", "run-server",
+            "--project_name", executor.context.project_name,
+            "--entity-id", executor.context.entity_ids[0],
+        ]
+        # args.extend(bundle_args) # keep this out for now
+
+        return await executor.get_launcher_response(
+            args=args
+        )

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -80,7 +80,7 @@ class ComfyUIAddon(BaseServerAddon):
                 success=False,
             )
 
-        if len(executor.context.entity_ids) > 0:
+        if len(executor.context.entity_ids) > 1:
             return await executor.get_simple_response(
                 message=(
                     "Failed to launch ComfyUI. "
@@ -96,7 +96,7 @@ class ComfyUIAddon(BaseServerAddon):
 
         args = [
             "addon", "comfyui", "run-server",
-            "--project_name", executor.context.project_name,
+            "--project-name", executor.context.project_name,
             "--entity-id", executor.context.entity_ids[0],
         ]
         # args.extend(bundle_args) # keep this out for now

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -40,8 +40,8 @@ class ComfyUIAddon(BaseServerAddon):
                 allow_multiselection=False,
                 icon={
                     "type": "material-symbols",
-                    "name": "terminal",
-                    "color": "#FF6600",
+                    "name": "robot",
+                    "color": "#A200FF",
                 },
             ),
             SimpleActionManifest(
@@ -53,8 +53,8 @@ class ComfyUIAddon(BaseServerAddon):
                 allow_multiselection=False,
                 icon={
                     "type": "material-symbols",
-                    "name": "terminal",
-                    "color": "#FF66FF",
+                    "name": "robot",
+                    "color": "#FFAB66",
                 },
             ),
         ]


### PR DESCRIPTION
## Changelog Description
This Draft is a suggestion for handling launching comfy without relying on `ayon-applications`.
Referring to conversation in https://github.com/ynput/ayon-applications/pull/107

## Additional review information
- removes(?) the ability to run pre launch hooks
- version selection would be lost by this

### TODO
* [ ] run on workfile selection
- [ ] on task selection support `Open Last Workfile`

## Testing notes:
1. build & upload to the server
2. from Launcher run the purple robot `Launch ComfyUI` action
