### PR TITLE
remove subfolder from files

### DIFF
--- a/client/ayon_comfyui/plugins/publish/collect_image.py
+++ b/client/ayon_comfyui/plugins/publish/collect_image.py
@@ -24,7 +24,10 @@ class CollectImage(pyblish.api.InstancePlugin):
         image_urls = host.stub.get_publish_node_images(instance.data)
         ext = ".png"
         instance.data["anatomyData"] = instance.context.data["anatomyData"]
-        staging_dir = get_instance_staging_dir(instance)
+        staging_dir = os.path.join(
+            get_instance_staging_dir(instance),
+            instance.data.get("productName"),
+        )
         self.log.info("Outputting image to %s", staging_dir)
 
         files = []
@@ -39,12 +42,8 @@ class CollectImage(pyblish.api.InstancePlugin):
             if filename is None:
                 continue
             self.log.debug("Got filename: %s", filename)
-            destination = os.path.join(
-                staging_dir, instance.data.get("productName"), filename
-            )
-            files.append(
-                os.path.join(instance.data.get("productName"), filename)
-            )
+            destination = os.path.join(staging_dir, filename)
+            files.append(filename)
             Path(destination).parent.mkdir(parents=True, exist_ok=True)
             urlretrieve(image, destination)  # noqa: S310
 

--- a/client/ayon_comfyui/plugins/publish/collect_image.py
+++ b/client/ayon_comfyui/plugins/publish/collect_image.py
@@ -26,7 +26,7 @@ class CollectImage(pyblish.api.InstancePlugin):
         instance.data["anatomyData"] = instance.context.data["anatomyData"]
         staging_dir = os.path.join(
             get_instance_staging_dir(instance),
-            instance.data.get("productName"),
+            instance.data["productName"],
         )
         self.log.info("Outputting image to %s", staging_dir)
 


### PR DESCRIPTION
## Changelog Description
don't include a subfolder in `files`

## Additional review information

follow up from: https://github.com/ynput/ayon-core/pull/1899
`files`  are supposed to be filenames only. This PR moves the subfolder into the `staging_dir` instead


## Testing notes:
1. publish

