### PR TITLE
fix: allow empty prefix and unique name

### DIFF
--- a/client/ayon_comfyui/_comfyui_plugin/ayon_menu/nodes/publish_nodes.py
+++ b/client/ayon_comfyui/_comfyui_plugin/ayon_menu/nodes/publish_nodes.py
@@ -19,6 +19,25 @@ from PIL.PngImagePlugin import PngInfo
 from torch import Tensor
 
 
+def get_filename_prefix(ayon_json: dict) -> str:
+
+    creator_attrs = ayon_json["creator_attributes"]
+    product_name = ayon_json["productName"]
+
+    file_prefix = creator_attrs.get("prefix", "")
+    use_unique_name = creator_attrs.get("use_unique_name", True)
+    unique_name = creator_attrs.get("unique_name", "")
+
+    if use_unique_name and unique_name:
+        file_prefix = f"{file_prefix}_{unique_name}"
+
+    # if no prefix or unique_name is provided, fallback to the product name
+    if not file_prefix:
+        file_prefix = product_name
+
+    return f"AYON/{product_name}/{file_prefix}"
+
+
 class AyonSaveNode(io.ComfyNode):
     """A node that allows the user to Batch Save images with metadata."""
 
@@ -63,12 +82,7 @@ class AyonSaveNode(io.ComfyNode):
             print_tb(e)
 
         creator_attrs = ayon_json["creator_attributes"]
-
         keep_metadata = creator_attrs["keep_metadata"]
-        file_prefix = creator_attrs["prefix"]
-        use_unique_name = creator_attrs["use_unique_name"]
-        unique_name = creator_attrs["unique_name"]
-
         compress_level = creator_attrs.get("compression_level", 4)
 
         output_dir = folder_paths.get_output_directory()
@@ -89,14 +103,10 @@ class AyonSaveNode(io.ComfyNode):
 
         # I'm choosing to ignore the counter, and we're just going to overwrite
         # the files.
-
-        full_prefix = file_prefix
-        if use_unique_name:
-            full_prefix += f"_{unique_name}"
-
+        full_prefix = get_filename_prefix(ayon_json)
         full_output_folder, filename, counter, subfolder, filename_prefix = (
             folder_paths.get_save_image_path(
-                f"AYON/{ayon_json['productName']}/{full_prefix}",
+                full_prefix,
                 output_dir,
                 images_in[0].shape[1],
                 images_in[0].shape[0],
@@ -181,9 +191,6 @@ class AyonSaveVideoNode(io.ComfyNode):
         creator_attrs = ayon_json["creator_attributes"]
 
         keep_metadata: bool = creator_attrs["keep_metadata"]
-        file_prefix: str = creator_attrs["prefix"]
-        use_unique_name: bool = creator_attrs["use_unique_name"]
-        unique_name: str = creator_attrs["unique_name"]
 
         # mp4/h264 | webm/vp9 | webm/av1
         formatcodec: str = creator_attrs["formatcodec"]
@@ -196,9 +203,7 @@ class AyonSaveVideoNode(io.ComfyNode):
 
         output_dir = folder_paths.get_output_directory()
 
-        full_prefix = file_prefix
-        if use_unique_name:
-            full_prefix += f"_{unique_name}"
+        full_prefix = get_filename_prefix(ayon_json)
 
         components = video_in.get_components()
         images, audio, fps, metadata = (
@@ -210,7 +215,7 @@ class AyonSaveVideoNode(io.ComfyNode):
 
         full_output_folder, filename, counter, subfolder, filename_prefix = (
             folder_paths.get_save_image_path(
-                f"AYON/{ayon_json['productName']}/{full_prefix}",
+                full_prefix,
                 output_dir,
                 images[0].shape[1],
                 images[0].shape[0],
@@ -441,20 +446,12 @@ class AyonSave3DModelNode(io.ComfyNode):
             print_tb(e)
 
         creator_attrs = ayon_json["creator_attributes"]
-
         keep_metadata = creator_attrs["keep_metadata"]
-        file_prefix = creator_attrs["prefix"]
-        use_unique_name = creator_attrs["use_unique_name"]
-        unique_name = creator_attrs["unique_name"]
-
         fallback_format = creator_attrs.get("fallback_format", "obj")
 
         output_dir = folder_paths.get_output_directory()
 
-        full_prefix = file_prefix
-        if use_unique_name:
-            full_prefix += f"_{unique_name}"
-
+        full_prefix = get_filename_prefix(ayon_json)
         if isinstance(mesh, Types.File3D):
             full_prefix += f"_{mesh.format}"
         else:
@@ -462,7 +459,7 @@ class AyonSave3DModelNode(io.ComfyNode):
 
         full_output_folder, filename, counter, subfolder, filename_prefix = (
             folder_paths.get_save_image_path(
-                f"AYON/{ayon_json['productName']}/{full_prefix}",
+                full_prefix,
                 output_dir,
             )
         )

--- a/client/ayon_comfyui/api/plugin.py
+++ b/client/ayon_comfyui/api/plugin.py
@@ -28,6 +28,23 @@ class ComfyUICreator(Creator):
         """Return stub stored on QRPCManager."""
         return QRPCManager.get_instance().stub
 
+    def get_full_product_name(
+        self,
+        variant: str,
+        prefix: str = "",
+        unique_name: str = "",
+    ) -> str:
+
+        name_parts = []
+        if prefix:
+            name_parts.append(prefix)
+
+        if unique_name:
+            name_parts.append(unique_name)
+
+        name_parts.append(variant)
+        return "_".join(name_parts)
+
 
 class ComfyUIAutoCreator(AutoCreator):
     """Generic ComfyUI autocreator to extend."""

--- a/client/ayon_comfyui/plugins/create/create_image.py
+++ b/client/ayon_comfyui/plugins/create/create_image.py
@@ -50,7 +50,9 @@ class CreateImage(ComfyUICreator):
         project_name = context.get_current_project_name()
         folder_path = context.get_current_folder_path()
         task_name = context.get_current_task_name()
-        # host_name = context.host_name
+
+        if not use_unique_name:
+            unique_name = ""
 
         prefix = re.sub(f"[^{PRODUCT_NAME_ALLOWED_SYMBOLS}]+", "", prefix)
 
@@ -67,10 +69,11 @@ class CreateImage(ComfyUICreator):
             }
         )
 
-        if use_unique_name:
-            product_name = f"{prefix}_{unique_name}_{product_name}"
-        else:
-            product_name = f"{prefix}_{product_name}"
+        product_name = self.get_full_product_name(
+            product_name,
+            prefix=prefix,
+            unique_name=unique_name,
+        )
 
         creator_attributes = {
             "keep_metadata": keep_metadata,

--- a/client/ayon_comfyui/plugins/create/create_model.py
+++ b/client/ayon_comfyui/plugins/create/create_model.py
@@ -55,7 +55,9 @@ class CreateModel(ComfyUICreator):
         project_name = context.get_current_project_name()
         folder_path = context.get_current_folder_path()
         task_name = context.get_current_task_name()
-        # host_name = context.host_name
+
+        if not use_unique_name:
+            unique_name = ""
 
         prefix = re.sub(f"[^{PRODUCT_NAME_ALLOWED_SYMBOLS}]+", "", prefix)
 
@@ -72,10 +74,11 @@ class CreateModel(ComfyUICreator):
             }
         )
 
-        if use_unique_name:
-            product_name = f"{prefix}_{unique_name}_{product_name}"
-        else:
-            product_name = f"{prefix}_{product_name}"
+        product_name = self.get_full_product_name(
+            product_name,
+            prefix=prefix,
+            unique_name=unique_name,
+        )
 
         creator_attributes = {
             "keep_metadata": keep_metadata,

--- a/client/ayon_comfyui/plugins/create/create_video.py
+++ b/client/ayon_comfyui/plugins/create/create_video.py
@@ -61,6 +61,9 @@ class CreateVideo(ComfyUICreator):
         folder_path = context.get_current_folder_path()
         task_name = context.get_current_task_name()
 
+        if not use_unique_name:
+            unique_name = ""
+
         prefix = re.sub(f"[^{PRODUCT_NAME_ALLOWED_SYMBOLS}]+", "", prefix)
 
         unique_name = re.sub(
@@ -76,10 +79,11 @@ class CreateVideo(ComfyUICreator):
             }
         )
 
-        if use_unique_name:
-            product_name = f"{prefix}_{unique_name}_{product_name}"
-        else:
-            product_name = f"{prefix}_{product_name}"
+        product_name = self.get_full_product_name(
+            product_name,
+            prefix=prefix,
+            unique_name=unique_name,
+        )
 
         creator_attributes = {
             "keep_metadata": keep_metadata,


### PR DESCRIPTION
## Changelog Description
Allows `prefix` and `unique_name` to be left empty

## Additional review information
When `prefix` and/or `unique_name` was left empty it would create leading underscores in the filename.
This PR adds a shared `get_full_product_name` method to concatenate the product_name.

It also updates the logic on the `publish_nodes` side. If a `prefix` and/or `unique_name` is provided it will still be used as the filename. If not, the `product_name` will be used instead.

in the following screenshot:
| prefix | unique_name | result |
| ------ | ----------- | ------ |
| "" | "" | `imageMain/imageMain_0001.png` |
| ayon | ayon | `ayon_ayon_imageMain/ayon_ayon_0001.png` |

<img width="316" height="162" alt="image" src="https://github.com/user-attachments/assets/79288ee2-947d-49f6-92cf-fe74e8eaf90e" />

## Testing notes:
1. set either prefix or unique name to be empty (or both, or neither)
2. publish
