### PR TITLE
Redesign Workfiles loading, saving and tracking current filepath.

### DIFF
--- a/client/ayon_comfyui/_comfyui_plugin/ayon_menu/js/ayon_menu.js
+++ b/client/ayon_comfyui/_comfyui_plugin/ayon_menu/js/ayon_menu.js
@@ -3,11 +3,11 @@ import "../../../../extensions/ayon_menu/lib/wsrpc.js";
 import {RPCServer} from "../../../../extensions/ayon_menu/lib/rpc_server.js"
 import {AYON_ORIGIN_ADRESS} from "../../../../extensions/ayon_menu/lib/consts.js"
 
-const AYON_EXTENSION_NAME = "comfy_ayon_menu"
+const AYON_EXTENSION_NAME = "AYON.ComfyMenu"
 const AYON_SIDEBAR_TAB_ID = "ayon"
 const AYON_SIDEBAR_ICON_CLASS = "ayon-sidebar-icon"
 const AYON_SIDEBAR_STYLE_ID = "ayon-sidebar-style"
-const AYON_ICON_URL = new URL("./assets/ayon-icon.png?v=20260506-ayon-icon", import.meta.url).href
+const AYON_ICON_URL = new URL("./assets/ayon-icon.png", import.meta.url).href
 const AYON_TOOL_ACTIONS = [
   {
     id: "showPublisher",
@@ -38,6 +38,12 @@ const AYON_TOOL_ACTIONS = [
     label: "Scene Inventory",
     tool_name: "sceneinventory",
     description: "Inspect AYON scene inventory items."
+  },
+  {
+    id: "showScriptEditor",
+    label: "Script Editor",
+    tool_name: "scripteditor",
+    description: "Open AYON Script Editor."
   }
 ]
 
@@ -56,7 +62,6 @@ function push_ayon_queue(function_name, args) {
 }
 
 function request_ayon_tool(tool_name) {
-  console.log(app.extensions);
   push_ayon_queue("ayonComfyUI.requestToolByName", {"tool_name": tool_name})
 }
 
@@ -108,6 +113,10 @@ function create_ayon_tool_panel(container) {
 
   root.append(header, actions)
   container.replaceChildren(root)
+}
+
+function get_workflow() {
+  return document.querySelector('#vue-app').__vue_app__.config.globalProperties.$pinia._s.get("workflow");
 }
 
 function ensure_ayon_sidebar_style() {
@@ -229,7 +238,7 @@ function register_ayon_sidebar_tab() {
 }
 
 app.registerExtension({
-    name: "comfy_ayon_menu",
+    name: AYON_EXTENSION_NAME,
     async afterConfigureGraph(graphData) {
 
         async function execute_single_node(node) {
@@ -544,7 +553,7 @@ app.registerExtension({
 
         function retrieve_latest_procqueue() {
           const exts = app.extensions;
-          const ext = exts.find((el) => el.name == "comfy_ayon_menu")
+          const ext = exts.find((el) => el.name == AYON_EXTENSION_NAME)
           if (ext.PROC_QUEUE.length > 0)
             return ext.PROC_QUEUE.pop()
           return null
@@ -579,10 +588,172 @@ app.registerExtension({
           return workfile
         })
 
-        this.IFRAMERPC.register('updateTab', (data) => {
-          console.log(data);
-          app.loadGraphData(app.graph.serialize(), true, true, data.new_name);
-          return true;
+        // Allow host to set arbitrary extra metadata on the currently opened graph
+        this.IFRAMERPC.register('setGraphExtra', (data) => {
+          try {
+            const extra_json = data.extra_json;
+            const extra = typeof extra_json === 'string' ? JSON.parse(extra_json) : extra_json;
+
+            // Update sessionStorage-stored workfile if present
+            const client = window.sessionStorage.getItem("clientId")
+            const workflow_key = `workflow:${client}`
+            let workfile = window.sessionStorage.getItem(workflow_key)
+            if (workfile == null){
+              workfile = get_workfiles_v2()
+            }
+
+            if (workfile) {
+              try {
+                const wf = typeof workfile === 'string' ? JSON.parse(workfile) : workfile;
+                wf.graph = wf.graph || {};
+                wf.graph.extra = wf.graph.extra || {};
+
+                Object.keys(extra).forEach((k) => {
+                  if (typeof extra[k] === 'object' && extra[k] !== null && typeof wf.graph.extra[k] === 'object') {
+                    wf.graph.extra[k] = { ...wf.graph.extra[k], ...extra[k] };
+                  } else {
+                    wf.graph.extra[k] = extra[k];
+                  }
+                });
+
+                window.sessionStorage.setItem(workflow_key, JSON.stringify(wf));
+              } catch (e) {
+                console.warn('Failed to update session-stored workfile:', e);
+              }
+            }
+
+            // Also attempt to update in-memory graph representation
+            if (app && app.graph && typeof app.graph.serialize === 'function') {
+              const g = app.graph.serialize();
+              g.extra = g.extra || {};
+              Object.keys(extra).forEach((k) => {
+                if (typeof extra[k] === 'object' && extra[k] !== null && typeof g.extra[k] === 'object') {
+                  g.extra[k] = { ...g.extra[k], ...extra[k] };
+                } else {
+                  g.extra[k] = extra[k];
+                }
+              });
+              // reload graph data with merged extra without altering nodes
+              // Update app.graph.extra directly to avoid triggering a new tab.
+              try {
+                app.graph.extra = app.graph.extra || {};
+                Object.keys(extra).forEach((k) => {
+                  if (typeof extra[k] === 'object' && extra[k] !== null && typeof app.graph.extra[k] === 'object') {
+                    app.graph.extra[k] = { ...app.graph.extra[k], ...extra[k] };
+                  } else {
+                    app.graph.extra[k] = extra[k];
+                  }
+                });
+                // mark graph dirty so UI reflects the change
+                if (typeof app.graph.setDirtyCanvas === 'function') {
+                  app.graph.setDirtyCanvas(true, true);
+                }
+              } catch (e) {
+                console.warn('Failed to set graph.extra directly:', e);
+              }
+            }
+
+            return true;
+          } catch (err) {
+            console.warn('setGraphExtra failed:', err);
+            return false;
+          }
+        })
+
+        // Expose a simple getter that returns graph.extra.AYON.workfile_path when available
+        this.IFRAMERPC.register('getWorkfilePath', (data) => {
+          try {
+            // Prefer in-memory graph value
+            if (app && app.graph) {
+              try {
+                const g = app.graph.serialize ? app.graph.serialize() : app.graph;
+                if (g && g.extra && g.extra.AYON && g.extra.AYON.workfile_path) {
+                  return g.extra.AYON.workfile_path;
+                }
+                if (g && g.graph && g.graph.extra && g.graph.extra.AYON && g.graph.extra.AYON.workfile_path) {
+                  return g.graph.extra.AYON.workfile_path;
+                }
+              } catch (e) {
+                console.warn('Failed to read in-memory graph:', e);
+              }
+            }
+
+            // Fallback to session-stored workfile
+            const client = window.sessionStorage.getItem("clientId")
+            const workflow_key = `workflow:${client}`
+            let workfile = window.sessionStorage.getItem(workflow_key)
+            if (workfile == null){
+              workfile = get_workfiles_v2()
+            }
+
+            if (workfile) {
+              try {
+                const wf = typeof workfile === 'string' ? JSON.parse(workfile) : workfile;
+                const path = wf?.graph?.extra?.AYON?.workfile_path ?? wf?.extra?.AYON?.workfile_path ?? null;
+                return path ?? null;
+              } catch (e) {
+                console.warn('Failed to parse session-stored workfile:', e);
+                return null;
+              }
+            }
+
+            return null;
+          } catch (err) {
+            console.warn('getWorkfilePath failed:', err);
+            return null;
+          }
+        })
+
+        // Return the full graph.extra object (stringified JSON). If data.key(s) provided, return filtered value(s).
+        this.IFRAMERPC.register('getGraphExtra', (data) => {
+          try {
+            let extraObj = {};
+
+            // Prefer in-memory graph
+            if (app && app.graph) {
+              try {
+                const g = app.graph.serialize ? app.graph.serialize() : app.graph;
+                extraObj = g?.extra ?? g?.graph?.extra ?? {};
+              } catch (e) {
+                console.warn('Failed to read in-memory graph for getGraphExtra:', e);
+              }
+            }
+
+            // Fallback to session-stored workfile if empty
+            if ((!extraObj || Object.keys(extraObj).length === 0)) {
+              const client = window.sessionStorage.getItem("clientId")
+              const workflow_key = `workflow:${client}`
+              let workfile = window.sessionStorage.getItem(workflow_key)
+              if (workfile == null){
+                workfile = get_workfiles_v2()
+              }
+              if (workfile) {
+                try {
+                  const wf = typeof workfile === 'string' ? JSON.parse(workfile) : workfile;
+                  extraObj = wf?.graph?.extra ?? wf?.extra ?? {};
+                } catch (e) {
+                  console.warn('Failed to parse session-stored workfile for getGraphExtra:', e);
+                }
+              }
+            }
+
+            // If caller requested a specific key or list of keys, filter
+            if (data && data.key) {
+              return JSON.stringify(extraObj[data.key] ?? null);
+            }
+            if (data && Array.isArray(data.keys)) {
+              const out = {};
+              data.keys.forEach((k) => {
+                out[k] = extraObj[k] ?? null;
+              });
+              return JSON.stringify(out);
+            }
+
+            return JSON.stringify(extraObj);
+          } catch (err) {
+            console.warn('getGraphExtra failed:', err);
+            return JSON.stringify({});
+          }
         })
 
         this.IFRAMERPC.register('addPublishNode', (data) => {
@@ -726,7 +897,6 @@ app.registerExtension({
           return true
         });
 
-        
 
         this.IFRAMERPC.register('setImprintContext', (data) => {
           console.log("setting context...", data)
@@ -776,6 +946,22 @@ app.registerExtension({
           return true
         })
 
+        this.IFRAMERPC.register('save', async (data) => {
+          try {
+            console.log("Saving:", data)
+            const workflow = get_workflow().activeWorkflow
+
+            if (data && data.filename) {
+              await workflow.rename(data.filename)
+            }
+            await workflow.save()
+            return true
+          } catch (err) {
+            console.warn('save handler failed:', err)
+            return false
+          }
+        })
+
       
         //this.RPC.connect();
     },
@@ -785,11 +971,6 @@ app.registerExtension({
       label: "Ping Ayon Plugin Websocket RPC server", 
       function: () => {
         push_ayon_queue("ayonComfyUI.pingAyonMenu", {"message": "Ping from web"})
-        // ext.RPC.call('ayonComfyUI.pingAyonMenu', {"message" :`Ping from web`}).then(function (data) {
-        // console.log('pong: ', data);
-        // }, function (error) {
-        //   alert(error);
-        // });
       } 
     },
     ...AYON_TOOL_ACTIONS.map((action) => ({
@@ -799,121 +980,6 @@ app.registerExtension({
         request_ayon_tool(action.tool_name)
       }
     })),
-
-    {
-      id: "saveLocal",
-      label: "Ayon Save Workfile",
-      function: () => {
-        function showToast(text, duration = 2000) {
-          const el = document.createElement("div");
-          el.textContent = text;
-              
-          Object.assign(el.style, {
-              position: "fixed",
-              top: "10px",
-              left: "10px",
-              background: "#249b9b",
-              color: "white",
-              padding: "8px 12px",
-              borderRadius: "6px",
-              zIndex: 9999,
-              fontSize: "14px",
-              fontFamily: "sans-serif",
-              boxShadow: "0 2px 6px rgba(0,0,0,0.3)",
-              opacity: "1",
-              transition: "opacity 0.3s ease"
-          });
-        
-          // attach to ComfyUI root instead of body if possible
-          (app.canvasElRef?.parentElement || document.body).appendChild(el);
-        
-          setTimeout(() => {
-              el.style.opacity = "0";
-              setTimeout(() => el.remove(), 300);
-          }, duration);
-        }
-
-        // v2 adapter for newer comfyui
-        function get_workfiles_save() {
-          // Attempt OpenPaths first.
-          const clientId = window.sessionStorage.getItem("clientId");
-          const openpath_str = window.sessionStorage.getItem(`Comfy.Workflow.OpenPaths:${clientId}`)
-          let path_str = null
-          if (openpath_str !== null) {
-            const openpath_parse = JSON.parse(openpath_str)
-            path_str = openpath_parse.paths[openpath_parse.activeIndex]
-          } else {
-            path_str = window.sessionStorage.getItem(`Comfy.Workflow.ActivePath:${clientId}`);
-            if (!path_str) {
-              return null;
-            }
-            path_str = JSON.parse(path_str).path;
-          }
-          const path = path_str
-
-          if (!path) {
-            return null;
-          }
-
-          const draftindex_str = window.localStorage.getItem("Comfy.Workflow.DraftIndex.v2:personal");
-          if (!draftindex_str) {
-            return null;
-          }
-
-          const draftindex = JSON.parse(draftindex_str);
-          const keys = Object.keys(draftindex.entries);
-
-          const personal_key = keys.filter((key) => {
-            if (draftindex.entries[key].path == path) {
-              return true;
-            }
-          })[0]
-
-          if (personal_key === undefined){
-            return null;
-          }
-
-          const data_str = window.localStorage.getItem(`Comfy.Workflow.Draft.v2:personal:${personal_key}`);
-          
-          if (!data_str) {
-            return null;
-          }
-          // workfiles data as a string
-          const data = JSON.parse(data_str).data
-
-          return data
-        }
-        
-        console.log("called save local")
-        // Attempt OpenPaths first, to get current tab.  
-        const clientId = window.sessionStorage.getItem("clientId");
-        const openpath_str = window.sessionStorage.getItem(`Comfy.Workflow.OpenPaths:${clientId}`)
-        let path_str = null
-        if (openpath_str !== null) {
-          const openpath_parse = JSON.parse(openpath_str)
-          path_str = openpath_parse.paths[openpath_parse.activeIndex]
-        } else {
-          const activepath_str = window.sessionStorage.getItem(`Comfy.Workflow.ActivePath:${clientId}`);
-          path_str = JSON.parse(activepath_str).path;
-          if (!path_str) {
-            return null;
-          }
-        }
-        const path = path_str
-
-        const formatted_path = path.replace(".json","").replace("workflows/","")
-      
-
-        const workfile = get_workfiles_save()
-
-        push_ayon_queue("ayonComfyUI.requestSaveByName", {"file_name": `${formatted_path}`, "workfile_contents": `${workfile}`})
-
-        showToast("Ayon Saved!")
-        
-      }
-
-
-    },
   ],
   // Add commands to menu
   menuCommands: [

--- a/client/ayon_comfyui/api/iframe/static/js/proxy.js
+++ b/client/ayon_comfyui/api/iframe/static/js/proxy.js
@@ -18,8 +18,24 @@ window.onload = async (e) => {
     return await IFRAME_RPC.call('getWorkfile', data)
   })
 
-  RPC.addRoute('updateTab', async (data) => {
-    return await IFRAME_RPC.call('updateTab', data)
+  // Allow host to set arbitrary extra metadata on the currently opened graph
+  RPC.addRoute('setGraphExtra', async (data) => {
+    return await IFRAME_RPC.call('setGraphExtra', data)
+  })
+
+  // Allow host to request the client save the current graph internally
+  RPC.addRoute('save', async (data) => {
+    return await IFRAME_RPC.call('save', data)
+  })
+
+  // Allow host to query the currently stored workfile path (if present)
+  RPC.addRoute('getWorkfilePath', async (data) => {
+    return await IFRAME_RPC.call('getWorkfilePath', data)
+  })
+
+  // Allow host to request the full graph.extra object (stringified JSON)
+  RPC.addRoute('getGraphExtra', async (data) => {
+    return await IFRAME_RPC.call('getGraphExtra', data)
   })
 
   RPC.addRoute('addPublishNode', async (data) => {

--- a/client/ayon_comfyui/api/pipeline.py
+++ b/client/ayon_comfyui/api/pipeline.py
@@ -46,13 +46,6 @@ class ComfyUIHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
     name = "comfyui"
 
-    _last_path: str = ""
-
-    def __init__(self):
-        super().__init__()
-        # Establish connection?
-        # If not done here then deperecate this.
-
     def get_app_information(self) -> ApplicationInformation:
         """Return application information."""
         return ApplicationInformation(
@@ -85,18 +78,36 @@ class ComfyUIHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
     def get_current_workfile(self):
         # Not too great, relies on a workfile having been opened
-        return self._last_path or None
+        return self.stub.get_workfile_path()
 
     def open_workfile(self, filepath):
         self.stub.load_workfile(filepath)
+        # After load, enforce that we track this file to exist at a certain
+        # path, so that `get_current_workfile` will report that path.
+        self.stub.set_workfile_path(filepath)
         return True
 
     def save_workfile(self, dst_path=None):
+        # Overwrite if no path is set
+        if dst_path is None:
+            dst_path = self.stub.get_workfile_path()
+            assert isinstance(dst_path, str)
+
+        # Set workfile path metadata inside the graph
+        self.stub.set_workfile_path(dst_path)
+
+        # Serialize the workfile and write it to disk
         workfile: str = self.stub.query_workfile()
         if workfile and isinstance(dst_path, str):
             with open(dst_path, mode="w", encoding="utf-8") as f:
                 f.write(workfile)
-                self.__class__._last_path = dst_path  # noqa: SLF001
+
+        # Save it 'internally' for ComfyUI too (perform Save As semantics)
+        # TODO: This would error if there's already another saved workflow with
+        #  same name. So we may need to ensure at least uniqueness within the
+        #  ComfyUI local storage
+        graph_name = os.path.splitext(os.path.basename(dst_path))[0]
+        self.stub.save(graph_name)
 
     @property
     def stub(self) -> RPCStub:

--- a/client/ayon_comfyui/api/rpc_server.py
+++ b/client/ayon_comfyui/api/rpc_server.py
@@ -27,8 +27,32 @@ logging.basicConfig(force=True, stream=sys.stdout, level=LOG_LEVEL)
 log = logging.getLogger("ayon_comfyui")
 
 
+def show_script_editor():
+    from ayon_core.tools.console_interpreter import InterpreterController
+    from ayon_core.tools.console_interpreter.ui import ConsoleInterpreterWindow
+    from qt import QtCore
+
+    # Global so it doesn't get garbage collected instantly
+    global console_window
+    if console_window is None:
+        controller = InterpreterController(name="comfyui")
+        console_window = ConsoleInterpreterWindow(controller)
+        console_window.setWindowTitle("Python Script Editor - ComfyUI")
+        console_window.setWindowFlags(
+            console_window.windowFlags() |
+            QtCore.Qt.Dialog |
+            QtCore.Qt.WindowMinimizeButtonHint)
+    console_window.show()
+    console_window.raise_()
+    console_window.activateWindow()
+
+
 def show_tool_by_name(tool_name: str) -> None:
     """Show host tool by name, with default settings."""
+    if tool_name == "scripteditor":
+        show_script_editor()
+        return
+
     kwargs = {}
     if tool_name == "loader":
         kwargs["use_context"] = True
@@ -42,52 +66,6 @@ def show_tool_by_name(tool_name: str) -> None:
 
     host_tools.show_tool_by_name(tool_name, **kwargs)
 
-
-# TODO(@sas): look for a better way to do this.
-#             ayon_api.get_representations is very slow.
-def _get_workfile_path_from_name(workfile_name: str) -> Path:
-    """Return found workfile path in representations, else None."""
-    paths = {
-        Path(x["attrib"]["path"]).stem: Path(x["attrib"]["path"])
-        for x in get_representations(
-            project_name="testing", representation_names=["json"]
-        )
-        if "workfile" in x["attrib"]["path"]
-    }
-    return paths.get(workfile_name)
-
-
-def _get_workfile_path_from_name_env(workfile_name: str) -> Path | None:
-    """Return found workfile path from AYON workdir folder, else None.
-
-    Raises:
-        FileNotFoundError: if workdir is not found
-    """
-    workdir = os.environ.get("AYON_WORKDIR")
-    if workdir is None:
-        raise FileNotFoundError("Workdir not found.")  # noqa: EM101
-
-    filepaths = (
-        Path(workdir) / file
-        for file in os.listdir(workdir)
-        if not os.path.isdir(os.path.join(workdir, file))
-        and Path(file).suffix == ".json"
-    )
-    path_dict = {p.stem: p for p in filepaths}
-    return path_dict.get(workfile_name)
-
-
-def overwrite_workfile(workfile_name: str, workfile_contents: str) -> None:
-    """Overwrite workfile if it exists.
-
-    Show workfiles menu if no path was matched.
-    """
-    path = _get_workfile_path_from_name_env(workfile_name=workfile_name)
-    if path:
-        path.write_text(data=workfile_contents, encoding="utf-8")
-        return
-    # As a backup, show workfiles.
-    show_tool_by_name("workfiles")
 
 
 def pull_origin_from_settings() -> str:
@@ -148,23 +126,6 @@ class AyonLocalHost(Route):
             self.qt_thread.schedule(show_tool_by_name, tool_name)
             return f"{tool_name} scheduled in qt_thread"
         return tool_name
-
-    @decorators.proxy
-    async def requestSaveByName(  # noqa: N802
-        self, file_name: str, workfile_contents: str
-    ) -> None:
-        """Schedule saving workfile in thread.
-
-        File name is without extension (as represented in ComfyUI tab)
-        """
-        log.debug(f"origin {self.socket.request.headers}")  # noqa: G004
-        log.debug("Saving workfile in place")
-        if self.qt_thread:
-            self.qt_thread.schedule(
-                overwrite_workfile, file_name, workfile_contents
-            )
-            return f"{file_name} save scheduled in qt_thread"
-        return file_name
 
 
 class RPCServerThread(Thread):

--- a/client/ayon_comfyui/api/rpc_stub.py
+++ b/client/ayon_comfyui/api/rpc_stub.py
@@ -81,13 +81,6 @@ class RPCClientStub:  # noqa: PLR0904
         """Call getWorkfile."""
 
     @call_on_origin()
-    def updateTab(self, *, new_name: str):  # noqa: N802, ANN201
-        """Call updateTab.
-
-        switches context to a new tab with a new name.
-        """
-
-    @call_on_origin()
     def loadWorkfile(self, *, workfile_json: str, workfile_name: str):  # noqa: N802, ANN201
         """Call loadWorkfile."""
 
@@ -110,6 +103,35 @@ class RPCClientStub:  # noqa: PLR0904
     @call_on_origin()
     def setImprintContext(self, *, imprint_info: str) -> bool:  # noqa: N802, ANN201
         """Call setImprintContext."""
+
+    @call_on_origin()
+    def setGraphExtra(self, *, extra_json: str):  # noqa: N802, ANN201
+        """Call setGraphExtra.
+
+        Allows host to set arbitrary extra metadata on the currently opened graph.
+        """
+
+    @call_on_origin()
+    def save(self, *, filename: str | None = None):  # noqa: N802, ANN201
+        """Call save.
+
+        Instruct the client to save the current graph internally (session/local storage).
+        Accepts an optional filename to perform a 'Save As' for the current tab.
+        """
+
+    @call_on_origin()
+    def getWorkfilePath(self):  # noqa: N802, ANN201
+        """Call getWorkfilePath.
+
+        Returns stored workfile path metadata from active graph, or null.
+        """
+
+    @call_on_origin()
+    def getGraphExtra(self):  # noqa: N802, ANN201
+        """Call getGraphExtra.
+
+        Returns stringified JSON of graph.extra (or {}).
+        """
 
     def do_context_imprint(self, imprint_info: str = "No imprint.") -> bool:
         """Creates a node in the browser session.
@@ -402,6 +424,86 @@ class RPCStub:  # noqa : PLR0904
         json_data = json.dumps(data)
         log.debug(json_data)
         self.client_stub.do_context_imprint(imprint_info=json_data)
+
+    def set_graph_extra(self, extra: dict) -> bool:
+        """Set arbitrary extra metadata on the currently opened graph.
+
+        The extra dict will be merged into graph.extra on the client side.
+        Returns True on success, None/False on failure.
+        """
+        log.debug(f"set_graph_extra\n{extra}")  # noqa: G004
+        try:
+            json_data = json.dumps(extra)
+            result = self.client_stub.setGraphExtra(extra_json=json_data)
+            return result
+        except Exception as e:  # noqa: BLE001
+            log.debug(f"set_graph_extra failed: {e}")  # noqa: G004
+            return None
+
+    def set_workfile_path(self, path: str) -> bool:
+        """Convenience to set AYON.workfile_path in graph.extra.AYON."""
+        return self.set_graph_extra({"AYON": {"workfile_path": path}})
+
+    def save(self, filename: str | None = None) -> bool:
+        """Instruct the client to save the current graph internally for ComfyUI.
+
+        If filename is provided, perform Save As semantics and set the client
+        workflow path accordingly.
+        """
+        log.debug(f"save graph via client filename={filename}")
+        try:
+            if filename is not None:
+                result = self.client_stub.save(filename=filename)
+            else:
+                result = self.client_stub.save()
+            return result
+        except Exception as e:  # noqa: BLE001
+            log.debug(f"save failed: {e}")  # noqa: G004
+            return False
+
+    def get_workfile_path(self) -> str | None:
+        """Return the stored workfile path from the active graph, or None."""
+        log.debug("get_workfile_path")
+        try:
+            res = self.client_stub.getWorkfilePath()
+            # client returns null/None or a string
+            return res if res else None
+        except Exception as e:  # noqa: BLE001
+            log.debug(f"get_workfile_path failed: {e}")  # noqa: G004
+            return None
+
+    def get_graph_extra(self, key: str | list[str] | None = None):
+        """Retrieve graph.extra from client and optionally filter by key(s).
+
+        If key is None, returns the full extra dict.
+        If key is a string, returns extra.get(key) or None.
+        If key is a list of strings, returns dict of those keys.
+        """
+        log.debug(f"get_graph_extra key={key}")
+        try:
+            raw = self.client_stub.getGraphExtra()
+            if not raw:
+                return None if key and isinstance(key, str) else {}
+
+            # raw expected to be a JSON string
+            try:
+                data = json.loads(raw) if isinstance(raw, str) else raw
+            except Exception:
+                data = {}
+
+            if key is None:
+                return data
+
+            if isinstance(key, str):
+                return data.get(key)
+
+            if isinstance(key, list):
+                return {k: data.get(k) for k in key}
+
+            return data
+        except Exception as e:  # noqa: BLE001
+            log.debug(f"get_graph_extra failed: {e}")  # noqa: G004
+            return None
 
     def _load_context(self) -> MutableMapping:
         """Query load entire context operation.

--- a/client/ayon_comfyui/hooks/pre_launch_args.py
+++ b/client/ayon_comfyui/hooks/pre_launch_args.py
@@ -11,6 +11,7 @@ from ayon_comfyui import get_launch_script_path
 from ayon_core.lib import (
     get_ayon_launcher_args,
     is_dev_mode_enabled,
+    is_staging_enabled,
     is_using_ayon_console,
 )
 
@@ -56,11 +57,16 @@ class ComfyPrelaunchHook(PreLaunchHook):
 
     def execute(self) -> None:
         script_path = get_launch_script_path()
-        # uses ayon_console to launch a script, respecting dev mode.
-        dev_args = ["--use-dev"] if is_dev_mode_enabled() else []
 
-        new_launch_args = get_ayon_launcher_args(*dev_args, "run", script_path)
+        # use ayon_console to launch a script
+        args = []
+        if is_dev_mode_enabled():
+            args.append("--use-dev")
+        elif is_staging_enabled():
+            args.append("--use-staging")
 
+
+        new_launch_args = get_ayon_launcher_args(*args, "run", script_path)
         self.launch_context.launch_args = new_launch_args
 
         self.launch_context.kwargs = get_launch_kwargs(

--- a/client/ayon_comfyui/plugins/publish/collect_current_file.py
+++ b/client/ayon_comfyui/plugins/publish/collect_current_file.py
@@ -1,0 +1,24 @@
+import pyblish.api
+
+from ayon_core.pipeline import registered_host
+
+
+class CollectCurrentFile(pyblish.api.ContextPlugin):
+    """Inject the current working file into context
+
+    Note that ComfyUI does not represent files on disk natively. As such, all
+    we can track is whether the current graph in some way was stored on disk
+    at some point, if we have stored that as metadata in the graph.
+    """
+
+    order = pyblish.api.CollectorOrder - 0.5
+    label = "Current Workfile"
+    hosts = ["comfyui"]
+
+    def process(self, context):
+        host = registered_host()
+        path = host.get_current_workfile()
+        context.data["currentFile"] = path
+        self.log.debug(f"Current workfile: {path}")
+        if path is None:
+            self.log.warning(f"Current workfile is unsaved.")

--- a/client/ayon_comfyui/plugins/publish/collect_image.py
+++ b/client/ayon_comfyui/plugins/publish/collect_image.py
@@ -32,9 +32,7 @@ class CollectImage(pyblish.api.InstancePlugin):
         for image in image_urls:
             self.log.debug("Downloading image: %s", image)
             parse = urlsplit(image)
-            self.log.debug(parse)
             query = parse_qs(parse.query)
-            self.log.debug(query)
             filename = next(iter(query.get("filename")), None)
             if filename is None:
                 continue
@@ -47,8 +45,6 @@ class CollectImage(pyblish.api.InstancePlugin):
             )
             Path(destination).parent.mkdir(parents=True, exist_ok=True)
             urlretrieve(image, destination)  # noqa: S310
-
-        instance.context.data["currentFile"] = files[0]
 
         if len(files) == 1:
             files = files[0]
@@ -67,8 +63,6 @@ class CollectImage(pyblish.api.InstancePlugin):
                 "tags": ["review"],
             }
         )
-
-        # NOTE(@sas): Maybe generate a tiled image for batched images
 
         thumbnail_img = files
         if isinstance(thumbnail_img, list):

--- a/client/ayon_comfyui/plugins/publish/collect_model.py
+++ b/client/ayon_comfyui/plugins/publish/collect_model.py
@@ -49,7 +49,6 @@ class CollectModel(pyblish.api.InstancePlugin):
             instance.data, publish_type=PublishType.MODEL3D
         )
 
-        instance.data["anatomyData"] = instance.context.data["anatomyData"]
         staging_dir = get_instance_staging_dir(instance)
         self.log.info("Outputting model to: %s", staging_dir)
 
@@ -61,9 +60,7 @@ class CollectModel(pyblish.api.InstancePlugin):
         # Download model
         self.log.debug("Downloading model: %s", model_link)
         parse = urlsplit(model_link)
-        self.log.debug(parse)
         query = parse_qs(parse.query)
-        self.log.debug(query)
         filename = next(iter(query.get("filename")), None)
         if filename is None:
             self.log.warning(
@@ -73,7 +70,7 @@ class CollectModel(pyblish.api.InstancePlugin):
         if (extension := Path(filename).suffix) not in self.model_exts:
             self.log.warning(
                 "Nothing could be collected. "
-                "(filename has invalid extension for video.)"
+                "(filename has invalid extension for model.)"
             )
             return
 
@@ -82,8 +79,6 @@ class CollectModel(pyblish.api.InstancePlugin):
         model_file = os.path.join(product_name, filename)
         Path(destination).parent.mkdir(parents=True, exist_ok=True)
         urlretrieve(model_link, destination)  # noqa: S310
-
-        instance.context.data["currentFile"] = model_file
 
         # creating representation
         instance.data["representations"].append(
@@ -94,4 +89,3 @@ class CollectModel(pyblish.api.InstancePlugin):
                 "stagingDir": staging_dir,
             }
         )
-        # no thumbnail here...

--- a/client/ayon_comfyui/plugins/publish/collect_video.py
+++ b/client/ayon_comfyui/plugins/publish/collect_video.py
@@ -53,13 +53,9 @@ class CollectVideo(pyblish.api.InstancePlugin):
         )
 
         video_info = VideoInfo()
-
         video_exts = {".mp4", ".webm"}
         video_info.thumbnail_extension = ".png"
 
-        # f"{filename}_{format}_thumb.png"
-
-        instance.data["anatomyData"] = instance.context.data["anatomyData"]
         staging_dir = get_instance_staging_dir(instance)
         self.log.debug("Outputting video to %s", staging_dir)
 
@@ -69,11 +65,8 @@ class CollectVideo(pyblish.api.InstancePlugin):
             return
 
         # Download video
-        self.log.debug(video_link)
         parse = urlsplit(video_link)
-        self.log.debug(parse)
         query = parse_qs(parse.query)
-        self.log.debug(query)
         filename = next(iter(query.get("filename")), None)
         if filename is None:
             self.log.warning(
@@ -87,8 +80,6 @@ class CollectVideo(pyblish.api.InstancePlugin):
             )
             return
         video_info.video_extension = extension
-        self.log.debug(filename)
-        self.log.debug(staging_dir)
         destination = os.path.join(
             staging_dir, instance.data.get("productName"), filename
         )
@@ -104,8 +95,7 @@ class CollectVideo(pyblish.api.InstancePlugin):
         thumb_url = parse._replace(
             query=naive_reconstruct_querydict(query)
         ).geturl()
-        self.log.debug("Retrieving generated thumbnail")
-        self.log.debug(thumb_url)
+        self.log.debug(f"Retrieving generated thumbnail via: {thumb_url}")
         thumb_destination = os.path.join(
             staging_dir, instance.data.get("productName"), thumb_filename
         )
@@ -113,8 +103,6 @@ class CollectVideo(pyblish.api.InstancePlugin):
         video_info.thumbnail_file = os.path.join(
             instance.data.get("productName"), thumb_filename
         )
-
-        instance.context.data["currentFile"] = video_info.video_file
 
         # marking instance as reviewable
         instance.data["review"] = True

--- a/client/ayon_comfyui/plugins/publish/collect_workfile.py
+++ b/client/ayon_comfyui/plugins/publish/collect_workfile.py
@@ -1,17 +1,17 @@
 import os
-import re
 
 import pyblish.api
-from ayon_comfyui.api.pipeline import ComfyUIHost
-from ayon_core.pipeline import (
-    registered_host,
-)
 
 
 class CollectWorkfile(pyblish.api.InstancePlugin):
-    """Collect current script for publish."""
+    """Collect current workflow path for publish.
 
-    order = pyblish.api.CollectorOrder + 0.1
+    Note: This does not 'save' the current workfile and hence it may use
+    an outdated state of the graph. It may make more sense to make this an
+    extractor and serialize it on extraction instead.
+    """
+
+    order = pyblish.api.CollectorOrder - 0.49
     label = "Collect Workfile"
     hosts = ["comfyui"]
     families = ["workfile"]
@@ -19,59 +19,23 @@ class CollectWorkfile(pyblish.api.InstancePlugin):
     default_variant = "Main"
 
     def process(self, instance):
-        proj = os.environ.get("AYON_PROJECT_NAME")[:3]
-        task = os.environ.get("AYON_TASK_NAME")
-        folder = os.environ.get("AYON_FOLDER_PATH").split("/")[-1]
-        workdir = os.environ.get("AYON_WORKDIR")
-        self.log.debug(workdir)
 
-        regex = rf"{proj}_{folder}_{task}" + r"_v(\d{3})[\w\.]+"
-        self.log.debug(os.listdir(workdir))
-        self.log.debug(regex)
-        files = [
-            file for file in os.listdir(workdir) if file.endswith(".json")
-        ]
-        self.log.debug("Work directory files: %s", files)
-        vers = [
-            int(re.match(regex, file).group(1))
-            for file in files
-            if re.match(regex, file) is not None
-        ]
-        max_ver = max(vers) if vers else 1
+        current_workfile: str | None = instance.context.data["currentFile"]
+        if current_workfile is None:
+            self.log.warning(
+                f"Can't collect current workfile because it's unsaved."
+            )
+            return
 
-        max_file = next(
-            (file for file in files if f"v{max_ver:03}" in file), None
-        )
-
-        ext = ".json"
-        instance.data["anatomyData"] = instance.context.data["anatomyData"]
-        self.log.debug(instance.data["anatomyData"])
-        instance.data["do_increment"] = True
-
-        # staging_dir = get_instance_staging_dir(instance)
-        staging_dir = workdir
-
-        if not vers or max_file is None:
-            max_file = f"{proj}_{folder}_{task}_v{max_ver:03}.json"
-            host: ComfyUIHost = registered_host()
-            host.save_workfile(os.path.join(staging_dir, max_file))
-            instance.data["do_increment"] = False
-        else:
-            pass
-            # save_next_version will do this
-            # source = os.path.join(workdir, max_file)
-            # destination = os.path.join(staging_dir, max_file)
-            #
-            # shutil.copy2(source, destination)
-
-        instance.context.data["currentFile"] = max_file
+        staging_dir, filename = os.path.split(current_workfile)
+        ext = os.path.splitext(filename)[1]
 
         # creating representation
-        instance.data["representations"].append(
+        instance.data.setdefault("representations", []).append(
             {
                 "name": ext[1:],
                 "ext": ext[1:],
-                "files": max_file,
+                "files": filename,
                 "stagingDir": staging_dir,
             }
         )

--- a/client/ayon_comfyui/plugins/publish/increment_workfile.py
+++ b/client/ayon_comfyui/plugins/publish/increment_workfile.py
@@ -8,12 +8,9 @@ import pyblish.api
 if TYPE_CHECKING:
     from ayon_comfyui.api.pipeline import ComfyUIHost
 
-from pathlib import Path
-
 from ayon_core.host.interfaces import SaveWorkfileOptionalData
 from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.publish import get_errored_plugins_from_context
-from ayon_core.pipeline.version_start import get_versioning_start
 from ayon_core.pipeline.workfile import (
     save_next_version,
 )
@@ -43,24 +40,7 @@ class IncrementWorkfile(pyblish.api.InstancePlugin):
         current_filepath: str = context.data["currentFile"]
         host: ComfyUIHost = registered_host()
 
-        # TODO(Roy): Why do we need this?
-        if not instance.data["do_increment"]:
-            self.log.info("Not incremented since first publish")
-
-            version = get_versioning_start(
-                context.data.get("projectName"),
-                host.name,
-                task_name=context.data["taskEntity"]["name"],
-                task_type=context.data["taskEntity"]["taskType"],
-                product_base_type="workfile",
-                product_name=instance.data["productName"],
-                project_settings=context.data["project_settings"],
-            )
-            if version > 1:
-                version -= 1
-
         current_filename = os.path.basename(current_filepath)
-
         save_next_version(
             version=version,
             description=(f"Incremented by publishing from {current_filename}"),
@@ -73,7 +53,4 @@ class IncrementWorkfile(pyblish.api.InstancePlugin):
         )
 
         new_scene_path = host.get_current_workfile()
-        new_name = Path(new_scene_path).stem
-        host.stub.client_stub.updateTab(new_name=new_name)
-
         self.log.info(f"Incremented workfile to: {new_scene_path}")  # noqa: G004


### PR DESCRIPTION
## Changelog Description

Redesign Workfiles loading, saving and tracking current filepath.

We now store `extra.AYON.workfile_path` data in the graph, which will be serialized along on our saves, but looks to also be persisting with ComfyUI's own local saves.

## Additional review information

This also makes some other tweaks, because it made sense while I was at it.

- AYON-ify extension name
- add Script Editor tool (to allow some debugging scripts to be run or other automations by the user)
- handle staging mode
- cleanup some workfiles handling mess during publishing

## Testing notes:

1. Integration should still work
2. Workfiles tool should work reliably
3. Publishing should work
